### PR TITLE
Interactive Pico Simulation Docs

### DIFF
--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -18,6 +18,7 @@ const docsSidebar = [
     text: 'Design',
     items: [
       { text: 'Overview', link: '/docs/design/overview' },
+      { text: 'Interactive cluster', link: '/docs/design/simulator' },
       { text: 'Metadata', link: '/docs/design/metadata' },
       { text: 'Streams', link: '/docs/design/streams' },
       { text: 'Writes', link: '/docs/design/writes' },

--- a/website/.vitepress/theme/simulation/HexBytes.vue
+++ b/website/.vitepress/theme/simulation/HexBytes.vue
@@ -1,0 +1,188 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import type { Seg } from './bytes';
+
+const props = defineProps<{ segs: Seg[]; title?: string }>();
+
+const KIND_COLORS: Record<string, string> = {
+  magic: '#8250df',
+  version: '#8250df',
+  type: '#bf3989',
+  int: '#0969da',
+  offset: '#1a7f37',
+  len: '#9a6700',
+  str: '#cf222e',
+  blob: '#cf222e',
+  crc: '#d4691e',
+  payload: '#cf222e',
+  count: '#9a6700',
+};
+
+const hovered = ref<number | null>(null);
+
+interface Cell {
+  hex: string;
+  segIdx: number;
+  color: string;
+}
+
+const cells = computed<Cell[]>(() => {
+  const out: Cell[] = [];
+  props.segs.forEach((seg, segIdx) => {
+    for (const b of seg.bytes) {
+      out.push({
+        hex: b.toString(16).padStart(2, '0'),
+        segIdx,
+        color: KIND_COLORS[seg.kind] ?? '#57606a',
+      });
+    }
+  });
+  return out;
+});
+
+const rows = computed(() => {
+  const out: { offset: number; cells: Cell[] }[] = [];
+  for (let i = 0; i < cells.value.length; i += 16) {
+    out.push({ offset: i, cells: cells.value.slice(i, i + 16) });
+  }
+  return out;
+});
+
+const totalBytes = computed(() => cells.value.length);
+</script>
+
+<template>
+  <div class="hexview">
+    <div class="hexview-head">
+      <span v-if="title" class="hexview-title">{{ title }}</span>
+      <span class="hexview-size">{{ totalBytes }} bytes</span>
+    </div>
+    <div class="hexview-body">
+      <div class="hexgrid">
+        <div v-for="row in rows" :key="row.offset" class="hexrow">
+          <span class="hexoff">{{ row.offset.toString(16).padStart(4, '0') }}</span>
+          <span
+            v-for="(cell, i) in row.cells"
+            :key="i"
+            class="hexbyte"
+            :class="{ dim: hovered !== null && hovered !== cell.segIdx }"
+            :style="{ color: cell.color }"
+            @mouseenter="hovered = cell.segIdx"
+            @mouseleave="hovered = null"
+            >{{ cell.hex }}</span
+          >
+        </div>
+      </div>
+      <div class="hexlegend">
+        <div
+          v-for="(seg, i) in segs"
+          :key="i"
+          class="hexfield"
+          :class="{ hot: hovered === i }"
+          @mouseenter="hovered = i"
+          @mouseleave="hovered = null"
+        >
+          <span class="swatch" :style="{ background: KIND_COLORS[seg.kind] ?? '#57606a' }" />
+          <span class="fname">{{ seg.label }}</span>
+          <span class="fval">{{ seg.value }}</span>
+          <span class="flen">{{ seg.bytes.length }} B</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.hexview {
+  border: 1px solid var(--pico-hairline);
+  background: var(--pico-surface-0, #fff);
+  font-size: 12px;
+  overflow: hidden;
+}
+.hexview-head {
+  display: flex;
+  justify-content: space-between;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--pico-hairline);
+  background: var(--pico-surface-1, #fafafa);
+}
+.hexview-title {
+  font-weight: 600;
+  color: var(--pico-ink-2);
+}
+.hexview-size {
+  color: var(--pico-ink-4);
+  font-family: var(--vp-font-family-mono);
+}
+.hexview-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+@media (max-width: 720px) {
+  .hexview-body {
+    grid-template-columns: 1fr;
+  }
+}
+.hexgrid {
+  padding: 8px 10px;
+  font-family: var(--vp-font-family-mono);
+  line-height: 1.7;
+  overflow-x: auto;
+  border-right: 1px solid var(--pico-hairline);
+}
+.hexrow {
+  white-space: nowrap;
+}
+.hexoff {
+  color: var(--pico-ink-6, #b0b6bd);
+  margin-right: 10px;
+  user-select: none;
+}
+.hexbyte {
+  margin-right: 5px;
+  cursor: default;
+  transition: opacity 0.12s;
+}
+.hexbyte.dim {
+  opacity: 0.22;
+}
+.hexlegend {
+  padding: 6px 8px;
+  max-height: 300px;
+  overflow-y: auto;
+}
+.hexfield {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  padding: 2px 6px;
+  cursor: default;
+}
+.hexfield.hot {
+  background: var(--pico-surface-2, #f2f3f5);
+}
+.swatch {
+  width: 8px;
+  height: 8px;
+  flex: none;
+  align-self: center;
+}
+.fname {
+  color: var(--pico-ink-2);
+  white-space: pre;
+}
+.fval {
+  color: var(--pico-ink-4);
+  font-family: var(--vp-font-family-mono);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+.flen {
+  color: var(--pico-ink-6, #b0b6bd);
+  font-family: var(--vp-font-family-mono);
+  flex: none;
+}
+</style>

--- a/website/.vitepress/theme/simulation/Simulation.vue
+++ b/website/.vitepress/theme/simulation/Simulation.vue
@@ -1,0 +1,1083 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
+import HexBytes from './HexBytes.vue';
+import { fmtBytes } from './bytes';
+import type { Seg } from './bytes';
+import { initialState, Sim, REAL, SIM } from './engine';
+import type { LogRow, S3Object } from './engine';
+
+const state = reactive(initialState());
+const sim = new Sim(state);
+
+const nodeCount = ref(2);
+const streamName = ref('/orders/eu');
+const payloadText = ref('{"order":1042,"total":18.5}');
+const appendStream = ref<number | null>(null);
+
+type Tab = 'memory' | 'postgres' | 's3' | 'bytes';
+const tab = ref<Tab>('postgres');
+const selectedNode = ref<number>(1);
+const inspected = ref<{ title: string; segs: Seg[]; note?: string } | null>(null);
+
+const runningStreams = computed(() => state.streams.filter((s) => s.state === 'opened'));
+const currentNode = computed(() => state.nodes.find((n) => n.id === selectedNode.value));
+const totalS3Bytes = computed(() => state.s3.reduce((n, o) => n + o.size, 0));
+
+// Edge geometry: measured from the DOM so the wires always meet the cards.
+const canvasEl = ref<HTMLElement | null>(null);
+const pgEl = ref<HTMLElement | null>(null);
+const s3El = ref<HTMLElement | null>(null);
+const nodeEls = new Map<number, HTMLElement>();
+function setNodeEl(id: number, el: unknown) {
+  if (el) nodeEls.set(id, el as HTMLElement);
+  else nodeEls.delete(id);
+}
+
+interface Edge {
+  nodeId: number;
+  side: 'pg' | 's3';
+  d: string;
+}
+const edges = ref<Edge[]>([]);
+const canvasSize = ref({ w: 0, h: 0 });
+
+function measure() {
+  const canvas = canvasEl.value;
+  const pg = pgEl.value;
+  const s3 = s3El.value;
+  if (!canvas || !pg || !s3) return;
+  const c = canvas.getBoundingClientRect();
+  canvasSize.value = { w: c.width, h: c.height };
+  const anchor = (el: HTMLElement, edge: 'left' | 'right') => {
+    const r = el.getBoundingClientRect();
+    return {
+      x: (edge === 'left' ? r.left : r.right) - c.left,
+      y: r.top + r.height / 2 - c.top,
+    };
+  };
+  const pgA = anchor(pg, 'right');
+  const s3A = anchor(s3, 'left');
+  const out: Edge[] = [];
+  for (const [nodeId, el] of nodeEls) {
+    const left = anchor(el, 'left');
+    const right = anchor(el, 'right');
+    const bend = (a: { x: number; y: number }, b: { x: number; y: number }) => {
+      const mx = (a.x + b.x) / 2;
+      return `M ${a.x} ${a.y} C ${mx} ${a.y}, ${mx} ${b.y}, ${b.x} ${b.y}`;
+    };
+    out.push({ nodeId, side: 'pg', d: bend(pgA, left) });
+    out.push({ nodeId, side: 's3', d: bend(right, s3A) });
+  }
+  edges.value = out;
+}
+
+onMounted(() => {
+  measure();
+  window.addEventListener('resize', measure);
+});
+onBeforeUnmount(() => window.removeEventListener('resize', measure));
+watch(
+  () => state.nodes.map((n) => n.id + n.status).join(),
+  () => nextTick(measure),
+);
+
+function edgeState(edge: Edge): '' | 'to-store' | 'from-store' {
+  const node = state.nodes.find((n) => n.id === edge.nodeId);
+  if (!node || node.status !== 'running') return '';
+  if (edge.side === 'pg') {
+    if (state.stage === 'logrow' && node.glow === 'propose') return 'to-store';
+    if ((state.stage === 'tailer' || state.stage === 'view') && node.glow !== '') return 'from-store';
+  } else {
+    if (state.stage === 's3put' && node.glow === 'propose') return 'to-store';
+  }
+  return '';
+}
+
+const MAP_ENTRY_BYTES: Record<string, number> = {
+  streams: 96,
+  nodes: 120,
+  opening_by_node: 24,
+  placed_by_node: 24,
+  stream_set_objects: 88,
+  sso_ranges: 32,
+  stream_objects: 72,
+  prepared: 24,
+  mark_destroyed: 40,
+  kv: 64,
+};
+
+const memoryRows = computed(() => {
+  const node = currentNode.value;
+  if (!node) return [];
+  return Object.entries(node.memory.viewMaps).map(([name, entries]) => ({
+    name,
+    entries,
+    bytes: entries * (MAP_ENTRY_BYTES[name] ?? 48),
+  }));
+});
+
+const memoryTotal = computed(() => {
+  const maps = memoryRows.value.reduce((n, r) => n + r.bytes, 0);
+  const cache = currentNode.value?.memory.logCache.reduce((n, e) => n + e.size, 0) ?? 0;
+  return maps + cache;
+});
+
+async function boot() {
+  await sim.boot(nodeCount.value);
+  appendStream.value = null;
+}
+
+async function createStream() {
+  if (!streamName.value.trim()) return;
+  await sim.createStream(streamName.value.trim());
+  appendStream.value = state.streams[state.streams.length - 1]?.id ?? null;
+  streamName.value = `/orders/${['eu', 'us', 'apac', 'latam'][state.streams.length % 4]}-${state.streams.length}`;
+}
+
+async function append() {
+  if (appendStream.value == null) return;
+  await sim.append(appendStream.value, payloadText.value);
+}
+
+function inspectRow(row: LogRow) {
+  inspected.value = {
+    title: `meta_log row ${row.idx}: ${row.commands.map((c) => c.name).join(' + ')}`,
+    segs: row.segs,
+    note: `The exact payload BYTEA: codec version byte, little-endian u32 command count, then each command body (type byte, fields in declaration order). Decoding this on any node replays the same state mutation.`,
+  };
+  tab.value = 'bytes';
+}
+
+function inspectObject(obj: S3Object) {
+  inspected.value = { title: `s3://pico/${obj.key}`, segs: obj.segs, note: obj.note };
+  tab.value = 'bytes';
+}
+
+function reset() {
+  sim.reset();
+  inspected.value = null;
+  tab.value = 'postgres';
+  selectedNode.value = 1;
+  appendStream.value = null;
+}
+
+const tasks = computed(() => sim.dueTasks());
+
+const metaStages: [string, string][] = [
+  ['propose', 'propose'],
+  ['flusher', 'flusher'],
+  ['logrow', 'log row'],
+  ['tailer', 'tailer'],
+  ['view', 'view'],
+];
+const dataStages: [string, string][] = [
+  ['wal', 'encode'],
+  ['s3put', 'put object'],
+];
+</script>
+
+<template>
+  <div class="csim">
+    <div class="meta-bar">
+      <label class="speed">
+        speed
+        <input v-model.number="state.speed" type="range" min="0.5" max="4" step="0.5" />
+        <span class="mono">{{ state.speed }}×</span>
+      </label>
+      <button v-if="state.booted" class="reset" :disabled="state.busy" @click="reset">reset</button>
+    </div>
+
+    <div v-if="state.booted" class="toolbar">
+      <div class="action-box">
+        <div class="action-kicker">streams</div>
+        <div class="op">
+          <div class="field">
+            <span class="field-label">Name</span>
+            <input v-model="streamName" class="txt" :disabled="state.busy" spellcheck="false" />
+          </div>
+          <button class="btn" :disabled="state.busy" @click="createStream">Create stream</button>
+        </div>
+        <div class="op-split"></div>
+        <div class="op" :class="{ locked: !runningStreams.length }">
+          <div class="fields">
+            <div class="field">
+              <span class="field-label">Stream</span>
+              <select v-model.number="appendStream" :disabled="state.busy || !runningStreams.length">
+                <option v-if="!runningStreams.length" :value="null">create a stream first</option>
+                <option v-for="s in runningStreams" :key="s.id" :value="s.id">{{ s.name }}</option>
+              </select>
+            </div>
+            <div class="field grow">
+              <span class="field-label">Record</span>
+              <input
+                v-model="payloadText"
+                class="txt"
+                :disabled="state.busy || !runningStreams.length"
+                spellcheck="false"
+              />
+            </div>
+          </div>
+          <button class="btn" :disabled="state.busy || appendStream == null" @click="append">
+            Append record
+          </button>
+        </div>
+      </div>
+
+      <div class="action-box">
+        <div class="action-kicker">background</div>
+        <p class="action-note">
+          Timers in a real cluster. Here they highlight when due. Click to run.
+        </p>
+        <div class="tasks">
+          <button
+            v-for="task in tasks"
+            :key="task.id"
+            class="task"
+            :class="{ due: task.due, ready: task.ready && !task.due }"
+            :disabled="state.busy || !task.ready"
+            :title="task.real"
+            @click="sim.runTask(task.id)"
+          >
+            <span class="task-top">
+              <span class="task-label">{{ task.label }}</span>
+              <span class="task-count mono">{{ task.count }}</span>
+            </span>
+            <span class="task-detail">{{ task.detail }}</span>
+            <span class="task-real">{{ task.real }}</span>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Canvas -->
+    <div ref="canvasEl" class="canvas">
+      <svg
+        class="wires"
+        :viewBox="`0 0 ${canvasSize.w} ${canvasSize.h}`"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <path
+          v-for="edge in edges"
+          :key="edge.nodeId + edge.side"
+          :d="edge.d"
+          class="wire"
+          :class="edgeState(edge)"
+        />
+      </svg>
+
+      <div ref="pgEl" class="store" @click="tab = 'postgres'">
+        <div class="store-kicker">fixed</div>
+        <div class="store-name">Postgres</div>
+        <div class="store-rows mono">
+          <div><span>meta_log</span><span>{{ state.log.length }} rows</span></div>
+          <div>
+            <span>meta_snapshot</span
+            ><span>{{ state.snapshot ? `idx ${state.snapshot.appliedIdx}` : 'empty' }}</span>
+          </div>
+          <div><span>meta_lease</span><span>{{ state.lease?.holder ?? 'none' }}</span></div>
+        </div>
+      </div>
+
+      <div class="nodes">
+        <div v-if="!state.nodes.length" class="boot">
+          <p class="boot-copy">Postgres and S3 are already waiting.</p>
+          <div class="boot-row">
+            <label class="field">
+              <span class="field-label">Nodes</span>
+              <select v-model.number="nodeCount" :disabled="state.busy">
+                <option v-for="n in [1, 2, 3, 4]" :key="n" :value="n">{{ n }}</option>
+              </select>
+            </label>
+            <button class="btn" :disabled="state.busy" @click="boot">Boot cluster</button>
+          </div>
+        </div>
+        <div
+          v-for="node in state.nodes"
+          :key="node.id"
+          :ref="(el) => setNodeEl(node.id, el)"
+          class="node"
+          :class="[node.status, node.glow, { selected: selectedNode === node.id }]"
+          @click="selectedNode = node.id; tab = 'memory'"
+        >
+          <div class="node-head">
+            <span class="node-name">node {{ node.id }}</span>
+            <span v-if="node.leaseHolder" class="lease" title="maintenance lease holder"></span>
+            <span class="node-state">{{ node.status }}</span>
+          </div>
+          <div class="node-rows mono">
+            <div><span>epoch</span><span>{{ node.epoch }}</span></div>
+            <div><span>applied</span><span>{{ node.memory.appliedIndex }}</span></div>
+            <div>
+              <span>streams</span
+              ><span>{{
+                state.streams.filter((s) => s.nodeId === node.id && s.state === 'opened').length
+              }}</span>
+            </div>
+            <div>
+              <span>buf</span
+              ><span>{{ state.walBuffer.filter((r) => r.nodeId === node.id).length }}</span>
+            </div>
+            <div>
+              <span>sealed</span
+              ><span>{{ state.sealedWal.filter((r) => r.nodeId === node.id).length }}</span>
+            </div>
+          </div>
+          <div class="node-actions">
+            <button
+              v-if="node.status === 'running'"
+              class="linkbtn danger"
+              :disabled="state.busy"
+              @click.stop="sim.killNode(node.id)"
+            >
+              kill
+            </button>
+            <button
+              v-if="node.status === 'dead'"
+              class="linkbtn"
+              :disabled="state.busy"
+              @click.stop="sim.restartNode(node.id)"
+            >
+              restart
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div ref="s3El" class="store" @click="tab = 's3'">
+        <div class="store-kicker">fixed</div>
+        <div class="store-name">Object store</div>
+        <div class="store-rows mono">
+          <div><span>objects</span><span>{{ state.s3.length }}</span></div>
+          <div><span>bytes</span><span>{{ fmtBytes(totalS3Bytes) }}</span></div>
+          <div><span>gc queue</span><span>{{ state.destroyedFifo.length }}</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="stagebar mono">
+      <span class="stagegroup">
+        <template v-for="([key, label], i) in metaStages" :key="key">
+          <span class="stage" :class="{ on: state.stage === key }">{{ label }}</span>
+          <span v-if="i < metaStages.length - 1" class="sep">·</span>
+        </template>
+      </span>
+      <span class="stagegroup">
+        <template v-for="([key, label], i) in dataStages" :key="key">
+          <span class="stage" :class="{ on: state.stage === key }">{{ label }}</span>
+          <span v-if="i < dataStages.length - 1" class="sep">·</span>
+        </template>
+      </span>
+    </div>
+
+    <!-- Panels -->
+    <div class="panels">
+      <div class="timeline">
+        <div class="kicker">timeline</div>
+        <div class="timeline-scroll">
+          <div v-if="!state.timeline.length" class="empty">nothing yet</div>
+          <div v-for="ev in state.timeline" :key="ev.seq" class="tl-event">
+            <span class="tl-dot" :class="ev.category"></span>
+            <span class="tl-at mono">{{ ev.at }}</span>
+            <span class="tl-text">{{ ev.text }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="inspector">
+        <div class="tabs">
+          <button :class="{ on: tab === 'memory' }" @click="tab = 'memory'">node memory</button>
+          <button :class="{ on: tab === 'postgres' }" @click="tab = 'postgres'">postgres</button>
+          <button :class="{ on: tab === 's3' }" @click="tab = 's3'">object store</button>
+          <button :class="{ on: tab === 'bytes' }" @click="tab = 'bytes'">bytes</button>
+        </div>
+
+        <div v-if="tab === 'memory'" class="tabbody">
+          <div v-if="!currentNode || currentNode.status === 'off'" class="empty">no node selected</div>
+          <template v-else>
+            <div class="mem-head">
+              <span class="kicker">node {{ currentNode.id }} resident state</span>
+              <span class="mono dim">≈ {{ fmtBytes(memoryTotal) }}</span>
+            </div>
+            <div v-if="currentNode.status === 'dead'" class="empty">
+              dead. Everything below was memory-only and is gone. The log, snapshot, and objects
+              survive in Postgres and S3.
+            </div>
+            <template v-else>
+              <div class="section">published view (im::OrdMap forks, O(1) to clone)</div>
+              <table class="mini">
+                <thead>
+                  <tr><th>map</th><th>entries</th><th>≈ bytes</th></tr>
+                </thead>
+                <tbody>
+                  <tr v-for="row in memoryRows" :key="row.name">
+                    <td class="mono">{{ row.name }}</td>
+                    <td class="mono num">{{ row.entries }}</td>
+                    <td class="mono num">{{ fmtBytes(row.bytes) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="section">log cache (encoded batches retained for reads)</div>
+              <div v-if="!currentNode.memory.logCache.length" class="empty">empty</div>
+              <table v-else class="mini">
+                <thead>
+                  <tr><th>stream</th><th>base offset</th><th>records</th><th>bytes</th></tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(e, i) in currentNode.memory.logCache" :key="i">
+                    <td class="mono">{{ e.streamId }}</td>
+                    <td class="mono num">{{ e.baseOffset }}</td>
+                    <td class="mono num">{{ e.count }}</td>
+                    <td class="mono num">{{ fmtBytes(e.size) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <p class="note">
+                Measured on the real thing: about 2.2 KiB resident per stream at one million
+                streams.
+              </p>
+            </template>
+          </template>
+        </div>
+
+        <div v-if="tab === 'postgres'" class="tabbody">
+          <div class="section">meta_log (idx BIGINT PK, payload BYTEA). Click a row to decode it.</div>
+          <div v-if="!state.log.length" class="empty">
+            {{ state.snapshot ? 'empty: everything below the snapshot was truncated' : 'no rows yet' }}
+          </div>
+          <table v-else class="mini clickable">
+            <thead>
+              <tr><th>idx</th><th>payload</th><th>bytes</th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="row in state.log" :key="row.idx" @click="inspectRow(row)">
+                <td class="mono num">{{ row.idx }}</td>
+                <td>{{ row.commands.map((c) => c.name).join(' + ') }}</td>
+                <td class="mono num">{{ row.bytes.length }}</td>
+              </tr>
+            </tbody>
+          </table>
+          <div class="section">meta_snapshot (id = 0, applied_idx, payload)</div>
+          <div v-if="!state.snapshot" class="empty">
+            none yet. Taken every {{ SIM.snapshotEvery }} rows here. The real cadence is
+            {{ REAL.snapshotEvery }} rows plus a {{ REAL.snapshotMinIntervalS }} s minimum interval.
+          </div>
+          <table v-else class="mini">
+            <thead>
+              <tr><th>applied_idx</th><th>payload</th><th>taken</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td class="mono num">{{ state.snapshot.appliedIdx }}</td>
+                <td class="mono">{{ fmtBytes(state.snapshot.size) }} (full state, one row per cluster)</td>
+                <td class="mono">{{ state.snapshot.takenAt }}</td>
+              </tr>
+            </tbody>
+          </table>
+          <div class="section">meta_lease</div>
+          <div v-if="!state.lease" class="empty">no holder</div>
+          <table v-else class="mini">
+            <thead><tr><th>holder</th><th>ttl</th></tr></thead>
+            <tbody>
+              <tr>
+                <td class="mono">{{ state.lease.holder }}</td>
+                <td class="mono">{{ state.lease.ttlMs }} ms</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div v-if="tab === 's3'" class="tabbody">
+          <div class="section">s3://pico. Click an object for its exact byte layout.</div>
+          <div v-if="!state.s3.length" class="empty">no objects. Append, Flush WAL, then Commit sealed.</div>
+          <table v-else class="mini clickable">
+            <thead>
+              <tr><th>key</th><th>kind</th><th>stream</th><th>offsets</th><th>size</th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="obj in state.s3" :key="obj.key" @click="inspectObject(obj)">
+                <td class="mono">{{ obj.key }}</td>
+                <td>{{ obj.kind }}</td>
+                <td class="mono num">{{ obj.streamId }}</td>
+                <td class="mono">[{{ obj.range[0] }}, {{ obj.range[1] }})</td>
+                <td class="mono num">{{ fmtBytes(obj.size) }}</td>
+              </tr>
+            </tbody>
+          </table>
+          <p class="note">
+            Record batches are stored verbatim: encoded once at append time, CRC-checked on read.
+            There is no recompression on the storage path. Compaction reclaims the per-append WAL
+            framing.
+          </p>
+        </div>
+
+        <div v-if="tab === 'bytes'" class="tabbody">
+          <div v-if="!inspected" class="empty">
+            click a meta_log row or an S3 object to see its exact bytes
+          </div>
+          <template v-else>
+            <HexBytes :segs="inspected.segs" :title="inspected.title" />
+            <p v-if="inspected.note" class="note">{{ inspected.note }}</p>
+          </template>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.csim {
+  border: 1px solid var(--pico-hairline);
+  background: var(--pico-surface-1, #fafafa);
+  margin: 24px 0;
+  font-size: 13.5px;
+  overflow: hidden;
+}
+.mono {
+  font-family: var(--vp-font-family-mono);
+  font-size: 12px;
+}
+.dim {
+  color: var(--pico-ink-4);
+}
+.empty {
+  color: var(--pico-ink-5, #8b929a);
+  padding: 8px 2px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.note {
+  color: var(--pico-ink-4);
+  font-size: 12.5px;
+  margin: 10px 0 0;
+  line-height: 1.55;
+}
+.kicker,
+.section {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--pico-ink-4);
+  font-weight: 600;
+}
+.section {
+  margin: 14px 0 6px;
+  font-weight: 500;
+  color: var(--pico-ink-5, #8b929a);
+  text-transform: none;
+  letter-spacing: 0.01em;
+  font-size: 12px;
+}
+
+.meta-bar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 14px;
+  padding: 6px 14px;
+  background: var(--pico-surface-0, #fff);
+  border-bottom: 1px solid var(--pico-hairline);
+}
+.speed {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--pico-ink-5, #8b929a);
+}
+.reset {
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: 11px;
+  color: var(--pico-ink-5, #8b929a);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.reset:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 0;
+  border-bottom: 1px solid var(--pico-hairline);
+  background: var(--pico-surface-0, #fff);
+}
+@media (max-width: 860px) {
+  .toolbar {
+    grid-template-columns: 1fr;
+  }
+}
+.action-box {
+  padding: 12px 14px 14px;
+  min-width: 0;
+}
+.action-box + .action-box {
+  border-left: 1px solid var(--pico-hairline);
+}
+.action-kicker {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--pico-ink-4);
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+.action-note {
+  margin: 0 0 8px;
+  font-size: 12px;
+  color: var(--pico-ink-4);
+  line-height: 1.45;
+}
+.op {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+.op.locked {
+  opacity: 0.4;
+}
+.op-split {
+  height: 1px;
+  background: var(--pico-hairline);
+  margin: 12px 0;
+}
+.fields {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+}
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+.field.grow {
+  flex: 1;
+}
+.field-label {
+  font-size: 11px;
+  color: var(--pico-ink-4);
+}
+.tasks {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+.task {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  text-align: left;
+  border: 1px solid var(--pico-ink-6, #c7ccd1);
+  background: var(--pico-surface-0, #fff);
+  padding: 6px 8px;
+  cursor: pointer;
+  color: var(--pico-ink-3);
+}
+.task:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+.task.ready:not(:disabled) {
+  border-color: var(--pico-ink-4);
+}
+.task.due:not(:disabled) {
+  border-color: var(--pico-accent, #1f2a37);
+  box-shadow: inset 3px 0 0 var(--pico-accent, #1f2a37);
+  opacity: 1;
+}
+.task-top {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  gap: 8px;
+}
+.task-label {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--pico-ink-1);
+}
+.task-count {
+  color: var(--pico-ink-3);
+}
+.task-detail,
+.task-real {
+  font-size: 11px;
+  color: var(--pico-ink-5, #8b929a);
+  line-height: 1.35;
+}
+.task.due .task-real {
+  color: var(--pico-ink-3);
+}
+.btn {
+  border: 1px solid var(--pico-ink-3);
+  background: var(--pico-surface-0, #fff);
+  padding: 6px 14px;
+  font-size: 13px;
+  cursor: pointer;
+  color: var(--pico-ink-1);
+  white-space: nowrap;
+}
+.btn:hover:not(:disabled) {
+  background: var(--pico-accent, #1f2a37);
+  border-color: var(--pico-accent, #1f2a37);
+  color: #fff;
+}
+.btn:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+select,
+.txt {
+  border: 1px solid var(--pico-ink-6, #c7ccd1);
+  padding: 5px 8px;
+  font-size: 12.5px;
+  background: var(--pico-surface-0, #fff);
+  color: var(--pico-ink-1);
+  font-family: var(--vp-font-family-mono);
+  box-sizing: border-box;
+  min-width: 120px;
+  width: 100%;
+}
+input[type='range'] {
+  width: 72px;
+  accent-color: var(--pico-accent, #1f2a37);
+}
+.boot {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 120px;
+  text-align: center;
+}
+.boot-copy {
+  margin: 0;
+  color: var(--pico-ink-5, #8b929a);
+  font-size: 13px;
+}
+.boot-row {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 8px;
+}
+.boot .field {
+  text-align: left;
+}
+.boot select {
+  width: 72px;
+  min-width: 72px;
+}
+
+/* Canvas */
+.canvas {
+  position: relative;
+  display: grid;
+  grid-template-columns: 176px 1fr 176px;
+  gap: 28px;
+  align-items: center;
+  padding: 26px 22px;
+  min-height: 190px;
+}
+.wires {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.wire {
+  fill: none;
+  stroke: var(--pico-ink-6, #d4d8dc);
+  stroke-width: 1;
+}
+.wire.to-store,
+.wire.from-store {
+  stroke: var(--pico-accent, #1f2a37);
+  stroke-width: 1.6;
+  stroke-dasharray: 5 5;
+  animation: flow 0.5s linear infinite;
+}
+.wire.from-store {
+  animation-direction: reverse;
+}
+@keyframes flow {
+  to {
+    stroke-dashoffset: -10;
+  }
+}
+
+.store {
+  position: relative;
+  border: 1px solid var(--pico-ink-6, #c7ccd1);
+  background: var(--pico-surface-2, #f2f3f5);
+  padding: 10px 12px 11px;
+  cursor: pointer;
+}
+.store-kicker {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--pico-ink-5, #8b929a);
+}
+.store-name {
+  font-weight: 600;
+  color: var(--pico-ink-1);
+  margin: 1px 0 7px;
+}
+.store-rows div,
+.node-rows div {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--pico-ink-3);
+  line-height: 1.75;
+}
+.store-rows span:last-child,
+.node-rows span:last-child {
+  color: var(--pico-ink-1);
+}
+
+.nodes {
+  position: relative;
+  display: flex;
+  gap: 18px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.nodes-empty {
+  color: var(--pico-ink-5, #8b929a);
+  font-size: 13px;
+  text-align: center;
+  line-height: 1.6;
+}
+.node {
+  position: relative;
+  border: 1px solid var(--pico-ink-6, #c7ccd1);
+  background: var(--pico-surface-0, #fff);
+  padding: 9px 12px 8px;
+  min-width: 148px;
+  cursor: pointer;
+  transition: box-shadow 0.18s, opacity 0.25s;
+}
+.node.selected {
+  border-color: var(--pico-ink-3);
+}
+.node.propose {
+  box-shadow: 0 0 0 3px rgb(31 42 55 / 0.14);
+}
+.node.apply {
+  box-shadow: 0 0 0 3px rgb(26 127 55 / 0.16);
+}
+.node.dead {
+  opacity: 0.45;
+  border-style: dashed;
+}
+.node.booting,
+.node.restoring {
+  border-style: dashed;
+}
+.node-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 5px;
+}
+.node-name {
+  font-weight: 600;
+  color: var(--pico-ink-1);
+  font-size: 13px;
+}
+.lease {
+  width: 7px;
+  height: 7px;
+  background: #1a7f37;
+  flex: none;
+}
+.node-state {
+  margin-left: auto;
+  font-size: 10.5px;
+  color: var(--pico-ink-5, #8b929a);
+}
+.node-actions {
+  margin-top: 5px;
+  min-height: 16px;
+}
+.linkbtn {
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: 11.5px;
+  color: var(--pico-ink-4);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.linkbtn.danger {
+  color: #b3261e;
+}
+.linkbtn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.stagebar {
+  display: flex;
+  justify-content: center;
+  gap: 34px;
+  padding: 0 14px 14px;
+  color: var(--pico-ink-5, #a8aeb5);
+  font-size: 11px;
+}
+.stagegroup {
+  display: inline-flex;
+  gap: 7px;
+  align-items: baseline;
+}
+.stage.on {
+  color: var(--pico-accent, #1f2a37);
+  font-weight: 700;
+}
+.sep {
+  color: var(--pico-ink-6, #d4d8dc);
+}
+
+/* Panels */
+.panels {
+  display: grid;
+  grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
+  border-top: 1px solid var(--pico-hairline);
+  background: var(--pico-surface-0, #fff);
+}
+@media (max-width: 860px) {
+  .panels {
+    grid-template-columns: 1fr;
+  }
+  .canvas {
+    grid-template-columns: 1fr;
+  }
+  .wires {
+    display: none;
+  }
+}
+.timeline {
+  border-right: 1px solid var(--pico-hairline);
+  padding: 12px 14px;
+  min-height: 300px;
+}
+.timeline-scroll {
+  margin-top: 8px;
+  max-height: 420px;
+  overflow-y: auto;
+}
+.tl-event {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--pico-hairline);
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+.tl-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  align-self: center;
+}
+.tl-dot.metadata {
+  background: #0969da;
+}
+.tl-dot.data {
+  background: #bf3989;
+}
+.tl-dot.lifecycle {
+  background: #1a7f37;
+}
+.tl-dot.storage {
+  background: #9a6700;
+}
+.tl-at {
+  color: var(--pico-ink-6, #b0b6bd);
+  flex: none;
+}
+.tl-text {
+  color: var(--pico-ink-2);
+}
+
+.inspector {
+  padding: 12px 14px;
+  min-width: 0;
+}
+.tabs {
+  display: flex;
+  gap: 2px;
+  border-bottom: 1px solid var(--pico-hairline);
+  margin-bottom: 10px;
+}
+.tabs button {
+  border: none;
+  background: none;
+  padding: 6px 11px;
+  font-size: 12.5px;
+  color: var(--pico-ink-4);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+}
+.tabs button.on {
+  color: var(--pico-ink-1);
+  border-bottom-color: var(--pico-accent, #1f2a37);
+  font-weight: 600;
+}
+.tabbody {
+  max-height: 430px;
+  overflow-y: auto;
+}
+.mem-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 4px;
+}
+.mini {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12.5px;
+  margin: 0;
+}
+.mini th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--pico-ink-4);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--pico-hairline);
+}
+.mini td {
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--pico-hairline);
+  color: var(--pico-ink-2);
+}
+.mini .num {
+  font-variant-numeric: tabular-nums;
+}
+.mini.clickable tbody tr {
+  cursor: pointer;
+}
+.mini.clickable tbody tr:hover {
+  background: var(--pico-surface-2, #f2f3f5);
+}
+</style>

--- a/website/.vitepress/theme/simulation/bytes.ts
+++ b/website/.vitepress/theme/simulation/bytes.ts
@@ -1,11 +1,4 @@
 // Byte-level building blocks mirroring the real wire formats.
-//
-// Metadata codec (picomq/pico-metadata/src/codec.rs): little-endian,
-// u32-length-prefixed strings/blobs.
-// Record batch codec (s3stream/s3stream-codec/src/codec.rs): big-endian,
-// magic 0x22, 33-byte header.
-// WAL framing (s3stream/s3stream-codec/src/wal_record.rs): big-endian,
-// 24-byte header, CRC-32/ISO-HDLC masked to 31 bits.
 
 export type SegKind =
   | 'magic'

--- a/website/.vitepress/theme/simulation/bytes.ts
+++ b/website/.vitepress/theme/simulation/bytes.ts
@@ -1,0 +1,155 @@
+// Byte-level building blocks mirroring the real wire formats.
+//
+// Metadata codec (picomq/pico-metadata/src/codec.rs): little-endian,
+// u32-length-prefixed strings/blobs.
+// Record batch codec (s3stream/s3stream-codec/src/codec.rs): big-endian,
+// magic 0x22, 33-byte header.
+// WAL framing (s3stream/s3stream-codec/src/wal_record.rs): big-endian,
+// 24-byte header, CRC-32/ISO-HDLC masked to 31 bits.
+
+export type SegKind =
+  | 'magic'
+  | 'version'
+  | 'type'
+  | 'int'
+  | 'offset'
+  | 'len'
+  | 'str'
+  | 'blob'
+  | 'crc'
+  | 'payload'
+  | 'count';
+
+export interface Seg {
+  label: string;
+  value: string;
+  kind: SegKind;
+  bytes: Uint8Array;
+}
+
+export function segsBytes(segs: Seg[]): Uint8Array {
+  const total = segs.reduce((n, s) => n + s.bytes.length, 0);
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const s of segs) {
+    out.set(s.bytes, at);
+    at += s.bytes.length;
+  }
+  return out;
+}
+
+export function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join(' ');
+}
+
+export class SegWriter {
+  segs: Seg[] = [];
+
+  private push(label: string, kind: SegKind, bytes: Uint8Array, value: string) {
+    this.segs.push({ label, kind, bytes, value });
+  }
+
+  u8(label: string, v: number, kind: SegKind = 'int') {
+    this.push(label, kind, new Uint8Array([v & 0xff]), String(v));
+  }
+
+  u32le(label: string, v: number, kind: SegKind = 'int') {
+    const b = new Uint8Array(4);
+    new DataView(b.buffer).setUint32(0, v >>> 0, true);
+    this.push(label, kind, b, String(v >>> 0));
+  }
+
+  i32le(label: string, v: number, kind: SegKind = 'int') {
+    const b = new Uint8Array(4);
+    new DataView(b.buffer).setInt32(0, v | 0, true);
+    this.push(label, kind, b, String(v | 0));
+  }
+
+  u64le(label: string, v: number | bigint, kind: SegKind = 'int') {
+    const b = new Uint8Array(8);
+    new DataView(b.buffer).setBigUint64(0, BigInt(v), true);
+    this.push(label, kind, b, String(v));
+  }
+
+  i64le(label: string, v: number | bigint, kind: SegKind = 'int') {
+    const b = new Uint8Array(8);
+    new DataView(b.buffer).setBigInt64(0, BigInt(v), true);
+    this.push(label, kind, b, String(v));
+  }
+
+  u32be(label: string, v: number, kind: SegKind = 'int') {
+    const b = new Uint8Array(4);
+    new DataView(b.buffer).setUint32(0, v >>> 0, false);
+    this.push(label, kind, b, String(v >>> 0));
+  }
+
+  i32be(label: string, v: number, kind: SegKind = 'int') {
+    const b = new Uint8Array(4);
+    new DataView(b.buffer).setInt32(0, v | 0, false);
+    this.push(label, kind, b, String(v | 0));
+  }
+
+  u64be(label: string, v: number | bigint, kind: SegKind = 'int') {
+    const b = new Uint8Array(8);
+    new DataView(b.buffer).setBigUint64(0, BigInt(v), false);
+    this.push(label, kind, b, String(v));
+  }
+
+  /// u32-LE length prefix + UTF-8 bytes (metadata codec `put_str`).
+  strLe(label: string, s: string) {
+    const bytes = new TextEncoder().encode(s);
+    this.u32le(`${label} len`, bytes.length, 'len');
+    this.push(label, 'str', bytes, JSON.stringify(s));
+  }
+
+  blobLe(label: string, bytes: Uint8Array, display?: string) {
+    this.u32le(`${label} len`, bytes.length, 'len');
+    this.push(label, 'blob', bytes, display ?? `${bytes.length} bytes`);
+  }
+
+  raw(label: string, bytes: Uint8Array, kind: SegKind, value?: string) {
+    this.push(label, kind, bytes, value ?? `${bytes.length} bytes`);
+  }
+
+  append(segs: Seg[]) {
+    this.segs.push(...segs);
+  }
+
+  bytes(): Uint8Array {
+    return segsBytes(this.segs);
+  }
+}
+
+// CRC-32/ISO-HDLC (the standard zlib crc32).
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    table[i] = c >>> 0;
+  }
+  return table;
+})();
+
+export function crc32(bytes: Uint8Array): number {
+  let c = 0xffffffff;
+  for (let i = 0; i < bytes.length; i++) {
+    c = CRC_TABLE[(c ^ bytes[i]) & 0xff] ^ (c >>> 8);
+  }
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+/// `WALUtil.crc32`: ISO-HDLC masked to 31 bits (s3stream-codec/src/crc.rs).
+export function walCrc32(bytes: Uint8Array): number {
+  return (crc32(bytes) & 0x7fffffff) >>> 0;
+}
+
+export function hexU32(v: number): string {
+  return '0x' + (v >>> 0).toString(16).padStart(8, '0');
+}
+
+export function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+  return `${(n / (1024 * 1024)).toFixed(2)} MiB`;
+}

--- a/website/.vitepress/theme/simulation/engine.ts
+++ b/website/.vitepress/theme/simulation/engine.ts
@@ -1,0 +1,1184 @@
+// The simulation engine. Every byte shown in the UI is produced by these
+// encoders, which mirror the real Rust codecs field for field:
+//
+// - metadata commands and log-row batches: picomq/pico-metadata/src/codec.rs
+//   (little-endian, version byte 0, type byte, fields in declaration order)
+// - record batches: s3stream/s3stream-codec (big-endian, magic 0x22)
+// - WAL framing: 24-byte header + CRC-32/ISO-HDLC masked to 31 bits
+//
+// The state machine follows docs/design/metadata.md: propose -> flusher
+// (group commit) -> log row -> tailer -> apply -> published view.
+
+import { Seg, SegWriter, walCrc32, hexU32, segsBytes } from './bytes';
+
+export const CODEC_VERSION = 0;
+export const MAGIC_V0 = 0x22;
+export const WAL_DATA_MAGIC = 0x87654321;
+
+// Real thresholds (shown in the UI) vs. the compressed ones the sim uses so
+// you can trigger everything in a few clicks.
+export const REAL = {
+  snapshotEvery: 1024,
+  snapshotMinIntervalS: 30,
+  compactAtObjects: 64,
+  groupCommitMax: 256,
+  walWindowMs: 5,
+  bytesPerStream: 2.2 * 1024,
+};
+export const SIM = {
+  snapshotEvery: 10,
+  compactAtObjects: 4,
+  flushAtRecords: 3,
+  commitAtWalObjects: 2,
+};
+
+// ---------------------------------------------------------------------------
+
+export type CommandName =
+  | 'RegisterNode'
+  | 'CreateStream'
+  | 'OpenStream'
+  | 'CloseStream'
+  | 'PlaceStream'
+  | 'PutKv'
+  | 'DeleteKv'
+  | 'PrepareObject'
+  | 'CommitStreamSetObject'
+  | 'CompactStreamObject'
+  | 'CleanDestroyedObjects'
+  | 'TransferStream'
+  | 'CompleteTransfer';
+
+export const TYPE_CODES: Record<CommandName, number> = {
+  CreateStream: 1,
+  OpenStream: 2,
+  CloseStream: 4,
+  PrepareObject: 6,
+  CommitStreamSetObject: 7,
+  CompactStreamObject: 8,
+  RegisterNode: 10,
+  CleanDestroyedObjects: 11,
+  PutKv: 12,
+  DeleteKv: 14,
+  TransferStream: 15,
+  CompleteTransfer: 16,
+  PlaceStream: 18,
+};
+
+export interface Command {
+  name: CommandName;
+  /** Display-friendly summary of the fields. */
+  summary: string;
+  /** Field name -> value used to build the encoding. */
+  args: Record<string, unknown>;
+  segs: Seg[];
+}
+
+function body(name: CommandName, build: (w: SegWriter) => void): Seg[] {
+  const w = new SegWriter();
+  w.u8(`type = ${name}`, TYPE_CODES[name], 'type');
+  build(w);
+  return w.segs;
+}
+
+export const enc = {
+  registerNode(nodeId: number, epoch: number, http: string, slots: number): Command {
+    return {
+      name: 'RegisterNode',
+      summary: `node ${nodeId} epoch ${epoch}, ${slots} slots`,
+      args: { nodeId, epoch, http, slots },
+      segs: body('RegisterNode', (w) => {
+        w.i32le('node_id', nodeId);
+        w.i64le('node_epoch', epoch);
+        w.strLe('http_address', http);
+        w.u32le('slots', slots);
+        w.u32le('protocol_addresses len', 0, 'len');
+      }),
+    };
+  },
+  createStream(nodeId: number, epoch: number): Command {
+    return {
+      name: 'CreateStream',
+      summary: `by node ${nodeId}`,
+      args: { nodeId, epoch },
+      segs: body('CreateStream', (w) => {
+        w.i32le('node_id', nodeId);
+        w.i64le('node_epoch', epoch);
+      }),
+    };
+  },
+  placeStream(streamId: number): Command {
+    return {
+      name: 'PlaceStream',
+      summary: `stream ${streamId} → least-loaded node`,
+      args: { streamId },
+      segs: body('PlaceStream', (w) => w.u64le('stream_id', streamId)),
+    };
+  },
+  openStream(nodeId: number, nodeEpoch: number, streamId: number, epoch: number): Command {
+    return {
+      name: 'OpenStream',
+      summary: `stream ${streamId} on node ${nodeId} at epoch ${epoch}`,
+      args: { nodeId, nodeEpoch, streamId, epoch },
+      segs: body('OpenStream', (w) => {
+        w.i32le('node_id', nodeId);
+        w.i64le('node_epoch', nodeEpoch);
+        w.u64le('stream_id', streamId);
+        w.i64le('epoch', epoch);
+      }),
+    };
+  },
+  putKv(key: string, value: Uint8Array, display: string): Command {
+    return {
+      name: 'PutKv',
+      summary: `${key} = ${display}`,
+      args: { key, display },
+      segs: body('PutKv', (w) => {
+        w.strLe('key', key);
+        w.blobLe('value', value, display);
+      }),
+    };
+  },
+  deleteKv(key: string): Command {
+    return {
+      name: 'DeleteKv',
+      summary: key,
+      args: { key },
+      segs: body('DeleteKv', (w) => w.strLe('key', key)),
+    };
+  },
+  prepareObject(nodeId: number, epoch: number, count: number, nowMs: number): Command {
+    return {
+      name: 'PrepareObject',
+      summary: `reserve ${count} object id${count > 1 ? 's' : ''}`,
+      args: { nodeId, epoch, count },
+      segs: body('PrepareObject', (w) => {
+        w.i32le('node_id', nodeId);
+        w.i64le('node_epoch', epoch);
+        w.u32le('count', count, 'count');
+        w.i64le('ttl_ms', 60_000);
+        w.i64le('now_ms', nowMs);
+      }),
+    };
+  },
+  commitStreamSetObject(
+    nodeId: number,
+    epoch: number,
+    objectId: number,
+    objectSize: number,
+    ranges: { streamId: number; epoch: number; start: number; end: number; size: number }[],
+    nowMs: number,
+  ): Command {
+    return {
+      name: 'CommitStreamSetObject',
+      summary: `object ${objectId} covers ${ranges
+        .map((r) => `stream ${r.streamId} [${r.start}, ${r.end})`)
+        .join(', ')}`,
+      args: { nodeId, objectId, objectSize, ranges },
+      segs: body('CommitStreamSetObject', (w) => {
+        w.i32le('node_id', nodeId);
+        w.i64le('node_epoch', epoch);
+        w.i64le('now_ms', nowMs);
+        w.u64le('object_id', objectId);
+        w.u64le('object_size', objectSize);
+        w.u32le('attributes', 0);
+        w.u32le('stream_ranges len', ranges.length, 'len');
+        for (const range of ranges) {
+          w.u64le('  stream_id', range.streamId);
+          w.u64le('  epoch', range.epoch);
+          w.u64le('  start_offset', range.start, 'offset');
+          w.u64le('  end_offset', range.end, 'offset');
+          w.u64le('  size', range.size);
+        }
+        w.u32le('stream_objects len', 0, 'len');
+        w.u32le('compacted_object_ids len', 0, 'len');
+      }),
+    };
+  },
+  compactStreamObject(
+    nodeId: number,
+    epoch: number,
+    objectId: number,
+    objectSize: number,
+    streamId: number,
+    streamEpoch: number,
+    start: number,
+    end: number,
+    sources: number[],
+    nowMs: number,
+  ): Command {
+    return {
+      name: 'CompactStreamObject',
+      summary: `stream ${streamId}: ${sources.length} objects → object ${objectId}`,
+      args: { nodeId, objectId, streamId, sources },
+      segs: body('CompactStreamObject', (w) => {
+        w.i32le('node_id', nodeId);
+        w.i64le('node_epoch', epoch);
+        w.i64le('now_ms', nowMs);
+        w.u64le('object_id', objectId);
+        w.u64le('object_size', objectSize);
+        w.u64le('stream_id', streamId);
+        w.u64le('stream_epoch', streamEpoch);
+        w.u64le('start_offset', start, 'offset');
+        w.u64le('end_offset', end, 'offset');
+        w.u32le('attributes', 0);
+        w.u32le('source_object_ids len', sources.length, 'len');
+        for (const id of sources) w.u64le('  source id', id);
+        w.u32le('operations len', sources.length, 'len');
+        for (const _ of sources) w.u8('  op = Delete', 0, 'type');
+      }),
+    };
+  },
+  cleanDestroyedObjects(ids: number[]): Command {
+    return {
+      name: 'CleanDestroyedObjects',
+      summary: `objects ${ids.join(', ')} removed from storage`,
+      args: { ids },
+      segs: body('CleanDestroyedObjects', (w) => {
+        w.u32le('object_ids len', ids.length, 'len');
+        for (const id of ids) w.u64le('  object id', id);
+      }),
+    };
+  },
+  transferStream(streamId: number, from: number, to: number): Command {
+    return {
+      name: 'TransferStream',
+      summary: `stream ${streamId}: node ${from} → node ${to}`,
+      args: { streamId, from, to },
+      segs: body('TransferStream', (w) => {
+        w.u64le('stream_id', streamId);
+        w.i32le('from_node', from);
+        w.i32le('to_node', to);
+      }),
+    };
+  },
+  completeTransfer(streamId: number, epoch: number): Command {
+    return {
+      name: 'CompleteTransfer',
+      summary: `stream ${streamId} now at epoch ${epoch}`,
+      args: { streamId, epoch },
+      segs: body('CompleteTransfer', (w) => {
+        w.u64le('stream_id', streamId);
+        w.i64le('epoch', epoch);
+      }),
+    };
+  },
+};
+
+/** One replicated-log row: version byte + u32 count + command bodies. */
+export function encodeBatchRow(commands: Command[]): Seg[] {
+  const w = new SegWriter();
+  w.u8(`codec version`, CODEC_VERSION, 'version');
+  w.u32le('command count', commands.length, 'count');
+  for (const c of commands) w.append(c.segs);
+  return w.segs;
+}
+
+// ---------------------------------------------------------------------------
+// Data plane: record batch (BE, magic 0x22) and WAL framing (24-byte header).
+
+export interface EncodedBatch {
+  streamId: number;
+  epoch: number;
+  baseOffset: number;
+  count: number;
+  payload: Uint8Array;
+  segs: Seg[];
+  bytes: Uint8Array;
+}
+
+export function encodeRecordBatch(
+  streamId: number,
+  epoch: number,
+  baseOffset: number,
+  count: number,
+  payload: Uint8Array,
+  payloadDisplay: string,
+): EncodedBatch {
+  const w = new SegWriter();
+  w.u8('magic', MAGIC_V0, 'magic');
+  w.u64be('stream_id', streamId);
+  w.u64be('epoch', epoch);
+  w.u64be('base_offset', baseOffset, 'offset');
+  w.i32be('last_offset_delta (count)', count, 'count');
+  w.u32be('payload length', payload.length, 'len');
+  w.raw('payload', payload, 'payload', payloadDisplay);
+  return { streamId, epoch, baseOffset, count, payload, segs: w.segs, bytes: w.bytes() };
+}
+
+export interface WalFrame {
+  segs: Seg[];
+  bytes: Uint8Array;
+  bodyCrc: number;
+  headerCrc: number;
+}
+
+export function frameWalRecord(offset: number, batch: EncodedBatch): WalFrame {
+  const bodyCrc = walCrc32(batch.bytes);
+  const head = new SegWriter();
+  head.u32be('magic (data)', WAL_DATA_MAGIC, 'magic');
+  head.u32be('body length', batch.bytes.length, 'len');
+  head.u64be('body offset', offset + 24, 'offset');
+  head.u32be(`body CRC = ${hexU32(bodyCrc)}`, bodyCrc, 'crc');
+  const headerCrc = walCrc32(head.bytes());
+  head.u32be(`header CRC = ${hexU32(headerCrc)}`, headerCrc, 'crc');
+  const w = new SegWriter();
+  w.append(head.segs);
+  w.append(batch.segs);
+  return { segs: w.segs, bytes: w.bytes(), bodyCrc, headerCrc };
+}
+
+// ---------------------------------------------------------------------------
+// Cluster state.
+
+export interface StreamRow {
+  id: number;
+  name: string;
+  epoch: number;
+  startOffset: number;
+  endOffset: number;
+  localEnd: number;
+  durableEnd: number;
+  state: 'opened' | 'closed';
+  nodeId: number;
+}
+
+export interface WalBuffered {
+  nodeId: number;
+  streamId: number;
+  batch: EncodedBatch;
+}
+
+export interface SealedWal {
+  objectId: number;
+  nodeId: number;
+  key: string;
+  size: number;
+  segs: Seg[];
+  ranges: { streamId: number; epoch: number; start: number; end: number; size: number }[];
+}
+
+export interface ObjectRow {
+  objectId: number;
+  streamId: number;
+  start: number;
+  end: number;
+  size: number;
+  kind: 'stream-set' | 'compacted';
+}
+
+export interface NodeMemory {
+  appliedIndex: number;
+  /** Entries retained in the log cache (recently appended batches). */
+  logCache: { streamId: number; baseOffset: number; count: number; size: number }[];
+  /** Per-map entry counts of the published im::OrdMap view. */
+  viewMaps: Record<string, number>;
+}
+
+export interface SimNode {
+  id: number;
+  epoch: number;
+  status: 'off' | 'booting' | 'running' | 'dead' | 'restoring';
+  slots: number;
+  leaseHolder: boolean;
+  memory: NodeMemory;
+  /** Transient animation flags. */
+  glow: '' | 'propose' | 'apply';
+}
+
+export interface LogRow {
+  idx: number;
+  commands: Command[];
+  segs: Seg[];
+  bytes: Uint8Array;
+}
+
+export interface S3Object {
+  key: string;
+  objectId: number;
+  kind: 'wal' | 'stream-set' | 'compacted';
+  size: number;
+  segs: Seg[];
+  note: string;
+  streamId: number;
+  range: [number, number];
+  nodeId?: number;
+}
+
+export interface TimelineEvent {
+  seq: number;
+  at: string;
+  category: 'metadata' | 'data' | 'lifecycle' | 'storage';
+  text: string;
+}
+
+export interface SimState {
+  booted: boolean;
+  busy: boolean;
+  speed: number;
+  nodes: SimNode[];
+  streams: StreamRow[];
+  objects: ObjectRow[];
+  destroyedFifo: { objectId: number; seq: number }[];
+  cleanerSeq: number;
+  kv: { key: string; display: string }[];
+  prepared: { objectId: number; owner: number }[];
+  log: LogRow[];
+  snapshot: { appliedIdx: number; size: number; takenAt: string } | null;
+  lease: { holder: string; ttlMs: number } | null;
+  s3: S3Object[];
+  timeline: TimelineEvent[];
+  nextStreamId: number;
+  nextObjectId: number;
+  nextLogIdx: number;
+  rowsSinceSnapshot: number;
+  walBuffer: WalBuffered[];
+  sealedWal: SealedWal[];
+  stage: '' | 'propose' | 'flusher' | 'logrow' | 'tailer' | 'view' | 'wal' | 's3put';
+  seq: number;
+}
+
+export interface DueTask {
+  id: 'flush' | 'commit' | 'snapshot' | 'compact' | 'gc';
+  label: string;
+  detail: string;
+  real: string;
+  count: string;
+  due: boolean;
+  ready: boolean;
+}
+
+export function initialState(): SimState {
+  return {
+    booted: false,
+    busy: false,
+    speed: 1,
+    nodes: [],
+    streams: [],
+    objects: [],
+    destroyedFifo: [],
+    cleanerSeq: 0,
+    kv: [],
+    prepared: [],
+    log: [],
+    snapshot: null,
+    lease: null,
+    s3: [],
+    timeline: [],
+    nextStreamId: 1,
+    nextObjectId: 1,
+    nextLogIdx: 1,
+    rowsSinceSnapshot: 0,
+    walBuffer: [],
+    sealedWal: [],
+    stage: '',
+    seq: 0,
+  };
+}
+
+const te = new TextEncoder();
+
+export class Sim {
+  constructor(public s: SimState) {}
+
+  private clock = 0;
+
+  now(): string {
+    this.clock += 1;
+    const m = Math.floor(this.clock / 60);
+    const sec = this.clock % 60;
+    return `${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+  }
+
+  log(category: TimelineEvent['category'], text: string) {
+    this.s.timeline.unshift({ seq: ++this.s.seq, at: this.now(), category, text });
+    if (this.s.timeline.length > 200) this.s.timeline.pop();
+  }
+
+  sleep(ms: number): Promise<void> {
+    return new Promise((r) => setTimeout(r, ms / this.s.speed));
+  }
+
+  private nodeMemory(): NodeMemory {
+    return { appliedIndex: 0, logCache: [], viewMaps: {} };
+  }
+
+  private refreshViewMaps() {
+    const streams = this.s.streams.length;
+    const opened = this.s.streams.filter((x) => x.state === 'opened').length;
+    const maps: Record<string, number> = {
+      streams: streams,
+      nodes: this.s.nodes.filter((n) => n.status !== 'off').length,
+      opening_by_node: opened,
+      placed_by_node: streams,
+      stream_set_objects: this.s.objects.filter((o) => o.kind === 'stream-set').length,
+      sso_ranges: this.s.objects.filter((o) => o.kind === 'stream-set').length,
+      stream_objects: this.s.objects.filter((o) => o.kind === 'compacted').length,
+      prepared: this.s.prepared.length,
+      mark_destroyed: this.s.destroyedFifo.length,
+      kv: this.s.kv.length,
+    };
+    for (const n of this.s.nodes) {
+      if (n.status === 'running') n.memory.viewMaps = { ...maps };
+    }
+  }
+
+  /** The full metadata write path for a batch of commands, animated. */
+  async propose(proposer: number, commands: Command[], apply: () => void) {
+    const node = this.s.nodes.find((n) => n.id === proposer);
+    if (node) node.glow = 'propose';
+    this.s.stage = 'propose';
+    this.log(
+      'metadata',
+      `node ${proposer} proposes ${commands.map((c) => c.name).join(' + ')}: queued for the flusher`,
+    );
+    await this.sleep(450);
+
+    this.s.stage = 'flusher';
+    this.log(
+      'metadata',
+      `flusher drains the queue: ${commands.length} command${commands.length > 1 ? 's' : ''} packed into one row (group commit, up to ${REAL.groupCommitMax}/row)`,
+    );
+    await this.sleep(450);
+
+    const segs = encodeBatchRow(commands);
+    const bytes = segsBytes(segs);
+    const idx = this.s.nextLogIdx++;
+    this.s.stage = 'logrow';
+    this.s.log.push({ idx, commands, segs, bytes });
+    this.s.rowsSinceSnapshot += 1;
+    this.log(
+      'metadata',
+      `INSERT INTO meta_log (idx, payload) VALUES (${idx}, x'...'), ${bytes.length} bytes. Uniqueness on idx is the only coordination`,
+    );
+    await this.sleep(500);
+
+    this.s.stage = 'tailer';
+    this.log('metadata', `every node's tailer fetches row ${idx} and applies it to its in-memory state`);
+    await this.sleep(450);
+
+    apply();
+    this.s.stage = 'view';
+    for (const n of this.s.nodes) {
+      if (n.status === 'running') {
+        n.memory.appliedIndex = idx;
+        n.glow = 'apply';
+      }
+    }
+    this.refreshViewMaps();
+    this.log(
+      'metadata',
+      `view published at applied index ${idx}: an O(1) fork of the persistent maps, readers never lock`,
+    );
+    await this.sleep(450);
+
+    this.s.stage = '';
+    for (const n of this.s.nodes) n.glow = '';
+
+  }
+
+  async boot(nodeCount: number) {
+    const s = this.s;
+    s.busy = true;
+    s.lease = null;
+    this.log('lifecycle', `cluster coming up. Postgres and the object store are already there. Nodes are the only moving piece`);
+    for (let i = 1; i <= nodeCount; i++) {
+      const node: SimNode = {
+        id: i,
+        epoch: 1,
+        status: 'booting',
+        slots: 4,
+        leaseHolder: false,
+        memory: this.nodeMemory(),
+        glow: '',
+      };
+      s.nodes.push(node);
+      this.log('lifecycle', `node ${i} starting: connects to Postgres, loads snapshot (none yet), tails the log`);
+      await this.sleep(400);
+      const cmd = enc.registerNode(i, 1, `http://10.0.0.${i}:4437`, 4);
+      await this.propose(i, [cmd], () => {
+        node.status = 'running';
+      });
+    }
+    s.nodes[0].leaseHolder = true;
+    s.lease = { holder: 'node-1', ttlMs: 10_000 };
+    this.log('lifecycle', `node 1 wins the maintenance lease (meta_lease row, TTL 10 s) and runs the expiry and GC ticks`);
+    s.booted = true;
+    s.busy = false;
+  }
+
+  async createStream(name: string) {
+    const s = this.s;
+    s.busy = true;
+    const id = s.nextStreamId++;
+    const running = s.nodes.filter((n) => n.status === 'running');
+    const counts = new Map(running.map((n) => [n.id, 0]));
+    for (const st of s.streams) {
+      if (counts.has(st.nodeId)) counts.set(st.nodeId, (counts.get(st.nodeId) ?? 0) + 1);
+    }
+    const owner = [...counts.entries()].sort((a, b) => a[1] - b[1])[0][0];
+    const proposer = running[0].id;
+
+    const create = enc.createStream(proposer, 1);
+    const place = enc.placeStream(id);
+    const open = enc.openStream(owner, 1, id, 1);
+    const registry = enc.putKv(name, te.encode(JSON.stringify({ stream_id: id })), `registry entry → stream ${id}`);
+
+    this.log('metadata', `create "${name}": four commands proposed back-to-back, watch them coalesce`);
+    await this.propose(proposer, [create, place, open, registry], () => {
+      s.streams.push({
+        id,
+        name,
+        epoch: 1,
+        startOffset: 0,
+        endOffset: 0,
+        localEnd: 0,
+        durableEnd: 0,
+        state: 'opened',
+        nodeId: owner,
+      });
+      s.kv.push({ key: name, display: `stream ${id}` });
+    });
+    this.log('lifecycle', `stream ${id} ("${name}") placed on node ${owner} (least-loaded by slots), opened at epoch 1`);
+    s.busy = false;
+  }
+
+  dueTasks(): DueTask[] {
+    const s = this.s;
+    const buffered = s.walBuffer.length;
+    const sealed = s.sealedWal.length;
+    const compactTarget = s.streams.find(
+      (st) => s.objects.filter((o) => o.streamId === st.id).length >= SIM.compactAtObjects,
+    );
+    const compactCount = compactTarget
+      ? s.objects.filter((o) => o.streamId === compactTarget.id).length
+      : Math.max(0, ...s.streams.map((st) => s.objects.filter((o) => o.streamId === st.id).length));
+    return [
+      {
+        id: 'flush',
+        label: 'Flush WAL',
+        detail: buffered
+          ? `${buffered} encoded record${buffered === 1 ? '' : 's'} in the node buffer`
+          : 'nothing buffered',
+        real: `real cluster: every ${REAL.walWindowMs} ms window. Ack waits for this PUT`,
+        count: `${buffered}/${SIM.flushAtRecords}`,
+        due: buffered >= SIM.flushAtRecords,
+        ready: buffered > 0,
+      },
+      {
+        id: 'commit',
+        label: 'Commit sealed',
+        detail: sealed
+          ? `${sealed} WAL object${sealed === 1 ? '' : 's'} durable but not in metadata`
+          : 'no sealed WAL waiting',
+        real: 'real cluster: background upload of sealed log-cache blocks, then Prepare + Commit',
+        count: `${sealed}/${SIM.commitAtWalObjects}`,
+        due: sealed >= SIM.commitAtWalObjects,
+        ready: sealed > 0,
+      },
+      {
+        id: 'snapshot',
+        label: 'Snapshot',
+        detail: `${s.rowsSinceSnapshot} log rows since the last snapshot`,
+        real: `real cluster: ${REAL.snapshotEvery} rows + ${REAL.snapshotMinIntervalS} s`,
+        count: `${s.rowsSinceSnapshot}/${SIM.snapshotEvery}`,
+        due: s.rowsSinceSnapshot >= SIM.snapshotEvery,
+        ready: s.log.length > 0,
+      },
+      {
+        id: 'compact',
+        label: 'Compact',
+        detail: compactTarget
+          ? `${compactTarget.name} has ${compactCount} live committed objects`
+          : compactCount
+            ? `most a stream holds is ${compactCount} committed objects`
+            : 'no committed stream objects yet',
+        real: `real cluster: ${REAL.compactAtObjects} live objects per stream`,
+        count: `${compactCount}/${SIM.compactAtObjects}`,
+        due: Boolean(compactTarget),
+        ready: Boolean(compactTarget),
+      },
+      {
+        id: 'gc',
+        label: 'Clean objects',
+        detail: s.destroyedFifo.length
+          ? `${s.destroyedFifo.length} destroyed object${s.destroyedFifo.length === 1 ? '' : 's'} in the FIFO`
+          : 'FIFO empty',
+        real: 'real cluster: lease holder ticks this in the background',
+        count: `${s.destroyedFifo.length}`,
+        due: s.destroyedFifo.length > 0,
+        ready: s.destroyedFifo.length > 0,
+      },
+    ];
+  }
+
+  async runTask(id: DueTask['id']) {
+    if (id === 'flush') await this.flushWal();
+    else if (id === 'commit') await this.commitSealed();
+    else if (id === 'snapshot') await this.takeSnapshot();
+    else if (id === 'compact') {
+      const target = this.s.streams.find(
+        (st) => this.s.objects.filter((o) => o.streamId === st.id).length >= SIM.compactAtObjects,
+      );
+      if (target) await this.compact(target.id);
+    } else await this.cleanerTick();
+  }
+
+  async append(streamId: number, text: string) {
+    const s = this.s;
+    const stream = s.streams.find((x) => x.id === streamId);
+    if (!stream) return;
+    const owner = s.nodes.find((n) => n.id === stream.nodeId);
+    if (!owner || owner.status !== 'running') return;
+    s.busy = true;
+    const payload = te.encode(text);
+    const base = stream.localEnd;
+
+    const batch = encodeRecordBatch(streamId, stream.epoch, base, 1, payload, JSON.stringify(text));
+    this.s.stage = 'wal';
+    owner.glow = 'propose';
+    owner.memory.logCache.push({ streamId, baseOffset: base, count: 1, size: batch.bytes.length });
+    s.walBuffer.push({ nodeId: owner.id, streamId, batch });
+    stream.localEnd = base + 1;
+    this.log(
+      'data',
+      `node ${owner.id} encodes the batch once into the WAL buffer and log cache (33-byte header, magic 0x22, ${payload.length}-byte payload). Not durable yet. The producer ack waits for the next WAL PUT. Metadata is not involved.`,
+    );
+    await this.sleep(350);
+    owner.glow = '';
+    this.s.stage = '';
+    if (s.walBuffer.length >= SIM.flushAtRecords) {
+      this.log(
+        'data',
+        `WAL buffer is at ${s.walBuffer.length} records (sim flush at ${SIM.flushAtRecords}, real window ${REAL.walWindowMs} ms). Flush WAL when you want to watch the durable PUT.`,
+      );
+    }
+    s.busy = false;
+  }
+
+  async flushWal() {
+    const s = this.s;
+    if (!s.walBuffer.length) return;
+    s.busy = true;
+    const byNode = new Map<number, WalBuffered[]>();
+    for (const rec of s.walBuffer) {
+      const list = byNode.get(rec.nodeId) ?? [];
+      list.push(rec);
+      byNode.set(rec.nodeId, list);
+    }
+    s.walBuffer = [];
+
+    for (const [nodeId, records] of byNode) {
+      const owner = s.nodes.find((n) => n.id === nodeId);
+      if (!owner || owner.status !== 'running') {
+        s.walBuffer.push(...records);
+        this.log('data', `node ${nodeId} is not running. Its ${records.length} buffered records stay local`);
+        continue;
+      }
+
+      const objectId = s.nextObjectId++;
+      const w = new SegWriter();
+      let offset = 0;
+      const ranges = new Map<number, { streamId: number; epoch: number; start: number; end: number; size: number }>();
+      for (const rec of records) {
+        const frame = frameWalRecord(offset, rec.batch);
+        w.append(frame.segs);
+        offset += frame.bytes.length;
+        const stream = s.streams.find((x) => x.id === rec.streamId);
+        const start = rec.batch.baseOffset;
+        const end = start + rec.batch.count;
+        const prev = ranges.get(rec.streamId);
+        if (prev) {
+          prev.end = Math.max(prev.end, end);
+          prev.size += frame.bytes.length;
+        } else {
+          ranges.set(rec.streamId, {
+            streamId: rec.streamId,
+            epoch: stream?.epoch ?? rec.batch.epoch,
+            start,
+            end,
+            size: frame.bytes.length,
+          });
+        }
+      }
+      const bytes = w.bytes();
+      const rangeList = [...ranges.values()];
+      const first = rangeList[0];
+      this.s.stage = 's3put';
+      owner.glow = 'propose';
+      const key = `wal/node-${nodeId}/${String(objectId).padStart(5, '0')}.wal`;
+      s.s3.push({
+        key,
+        objectId,
+        kind: 'wal',
+        size: bytes.length,
+        segs: w.segs,
+        note: `${records.length} framed record${records.length === 1 ? '' : 's'} from one WAL window. Durable staging under the node's session prefix. Not yet visible in metadata.`,
+        streamId: first.streamId,
+        range: [first.start, first.end],
+        nodeId,
+      });
+      s.sealedWal.push({
+        objectId,
+        nodeId,
+        key,
+        size: bytes.length,
+        segs: w.segs,
+        ranges: rangeList,
+      });
+      for (const range of rangeList) {
+        const stream = s.streams.find((x) => x.id === range.streamId);
+        if (stream) stream.durableEnd = Math.max(stream.durableEnd, range.end);
+      }
+      this.log(
+        'storage',
+        `PUT s3://pico/${key}, ${bytes.length} bytes. WAL staging only. Producers that were waiting on this window are acked here. Stream end offsets in metadata are unchanged.`,
+      );
+      await this.sleep(700);
+      owner.glow = '';
+      this.s.stage = '';
+      if (s.sealedWal.length >= SIM.commitAtWalObjects) {
+        this.log(
+          'data',
+          `${s.sealedWal.length} sealed WAL object${s.sealedWal.length === 1 ? '' : 's'} waiting. Commit sealed uploads stream-set objects and advances end offsets through metadata.`,
+        );
+      }
+    }
+    s.busy = false;
+  }
+
+  async commitSealed() {
+    const s = this.s;
+    if (!s.sealedWal.length) return;
+    s.busy = true;
+    const batch = [...s.sealedWal];
+    s.sealedWal = [];
+
+    for (const sealed of batch) {
+      const owner = s.nodes.find((n) => n.id === sealed.nodeId);
+      if (!owner || owner.status !== 'running') {
+        s.sealedWal.push(sealed);
+        this.log(
+          'data',
+          `node ${sealed.nodeId} is not running. Sealed WAL ${sealed.key} stays durable on S3 until an owner recovers it`,
+        );
+        continue;
+      }
+
+      const objectId = s.nextObjectId++;
+      const prep = enc.prepareObject(owner.id, owner.epoch, 1, this.clock * 1000);
+      await this.propose(owner.id, [prep], () => {
+        s.prepared.push({ objectId, owner: owner.id });
+      });
+
+      const w = new SegWriter();
+      w.append(
+        sealed.segs.map((seg) => ({
+          ...seg,
+          label: seg.label.startsWith('[wal') ? seg.label : `[from ${sealed.key}] ${seg.label}`,
+        })),
+      );
+      const bytes = w.bytes();
+      const first = sealed.ranges[0];
+      this.s.stage = 's3put';
+      owner.glow = 'propose';
+      const key = `stream-set/${String(objectId).padStart(5, '0')}.sso`;
+      s.s3.push({
+        key,
+        objectId,
+        kind: 'stream-set',
+        size: bytes.length,
+        segs: w.segs,
+        note: `Stream-set object built from sealed WAL ${sealed.key}. Readers learn about it only after CommitStreamSetObject.`,
+        streamId: first.streamId,
+        range: [Math.min(...sealed.ranges.map((r) => r.start)), Math.max(...sealed.ranges.map((r) => r.end))],
+      });
+      this.log(
+        'storage',
+        `PUT s3://pico/${key}, ${bytes.length} bytes: sealed block rewritten as a stream-set object. Still invisible to readers until metadata commit.`,
+      );
+      await this.sleep(600);
+      owner.glow = '';
+      this.s.stage = '';
+
+      const commit = enc.commitStreamSetObject(
+        owner.id,
+        owner.epoch,
+        objectId,
+        bytes.length,
+        sealed.ranges,
+        this.clock * 1000,
+      );
+      await this.propose(owner.id, [commit], () => {
+        s.prepared = s.prepared.filter((p) => p.objectId !== objectId);
+        for (const range of sealed.ranges) {
+          const stream = s.streams.find((x) => x.id === range.streamId);
+          if (stream) stream.endOffset = Math.max(stream.endOffset, range.end);
+          s.objects.push({
+            objectId,
+            streamId: range.streamId,
+            start: range.start,
+            end: range.end,
+            size: range.size,
+            kind: 'stream-set',
+          });
+        }
+      });
+
+      s.s3 = s.s3.filter((x) => x.objectId !== sealed.objectId);
+      this.log(
+        'storage',
+        `DELETE s3://pico/${sealed.key}: covered by committed stream-set object ${objectId}`,
+      );
+      this.log(
+        'data',
+        `CommitStreamSetObject published object ${objectId}. Stream end offsets in metadata now cover the sealed ranges. Readers can find them via sso_ranges.`,
+      );
+      await this.sleep(300);
+    }
+    s.busy = false;
+  }
+
+  async compact(streamId: number) {
+    const s = this.s;
+    const stream = s.streams.find((x) => x.id === streamId);
+    if (!stream) return;
+    const owner = s.nodes.find((n) => n.id === stream.nodeId);
+    if (!owner || owner.status !== 'running') return;
+    s.busy = true;
+    const sources = s.objects.filter((o) => o.streamId === streamId);
+    if (sources.length < 2) {
+      s.busy = false;
+      return;
+    }
+
+    const objectId = s.nextObjectId++;
+    const start = Math.min(...sources.map((o) => o.start));
+    const end = Math.max(...sources.map((o) => o.end));
+
+    const w = new SegWriter();
+    let concatenated = 0;
+    for (const src of sources) {
+      const obj = s.s3.find((x) => x.objectId === src.objectId);
+      if (obj) {
+        const bodySegs = obj.segs.slice(5);
+        w.append(bodySegs.map((seg) => ({ ...seg, label: `[obj ${src.objectId}] ${seg.label}` })));
+        concatenated += bodySegs.reduce((n, seg) => n + seg.bytes.length, 0);
+      }
+    }
+    const size = concatenated;
+
+    this.s.stage = 's3put';
+    const key = `stream/${streamId}/${String(objectId).padStart(5, '0')}.obj`;
+    s.s3.push({
+      key,
+      objectId,
+      kind: 'compacted',
+      size,
+      segs: w.segs,
+      note: `${sources.length} source objects rewritten as contiguous record batches [${start}, ${end}). WAL framing dropped, ${sources.reduce((n, o) => n + o.size, 0) - size} bytes of framing overhead reclaimed`,
+      streamId,
+      range: [start, end],
+    });
+    this.log('storage', `PUT s3://pico/${key}: compacted object ${objectId}, ${size} bytes for offsets [${start}, ${end})`);
+    await this.sleep(700);
+    this.s.stage = '';
+
+    const cmd = enc.compactStreamObject(
+      owner.id,
+      owner.epoch,
+      objectId,
+      size,
+      streamId,
+      stream.epoch,
+      start,
+      end,
+      sources.map((o) => o.objectId),
+      this.clock * 1000,
+    );
+    await this.propose(owner.id, [cmd], () => {
+      s.objects = s.objects.filter((o) => o.streamId !== streamId);
+      s.objects.push({ objectId, streamId, start, end, size, kind: 'compacted' });
+      for (const src of sources) {
+        s.destroyedFifo.push({ objectId: src.objectId, seq: ++s.cleanerSeq });
+      }
+    });
+    this.log(
+      'lifecycle',
+      `${sources.length} source objects queued in the destroyed FIFO (backlog ${s.destroyedFifo.length}). Clean objects when you want the lease holder to drain it.`,
+    );
+    s.busy = false;
+  }
+
+  async cleanerTick() {
+    const s = this.s;
+    if (!s.destroyedFifo.length) return;
+    s.busy = true;
+    const holder = s.nodes.find((n) => n.leaseHolder && n.status === 'running');
+    if (!holder) {
+      this.log('lifecycle', 'no maintenance lease holder. The destroyed FIFO backlog sits until one is elected');
+      s.busy = false;
+      return;
+    }
+    const ids = s.destroyedFifo.map((d) => d.objectId);
+    this.log('lifecycle', `lease holder node ${holder.id} drains the FIFO: DELETE ${ids.length} objects from the store`);
+    await this.sleep(500);
+    for (const id of ids) {
+      const obj = s.s3.find((x) => x.objectId === id);
+      if (obj) this.log('storage', `DELETE s3://pico/${obj.key}`);
+    }
+    s.s3 = s.s3.filter((x) => !ids.includes(x.objectId));
+    const cmd = enc.cleanDestroyedObjects(ids);
+    await this.propose(holder.id, [cmd], () => {
+      s.destroyedFifo = [];
+    });
+    s.busy = false;
+  }
+
+  async takeSnapshot() {
+    const s = this.s;
+    const holderNode = s.nodes.find((n) => n.status === 'running');
+    if (!holderNode || !s.log.length) return;
+    s.busy = true;
+    const appliedIdx = s.log[s.log.length - 1].idx;
+    const size =
+      64 + s.streams.length * 96 + s.objects.length * 72 + s.kv.length * 48 + s.nodes.length * 64;
+    this.log(
+      'metadata',
+      `${s.rowsSinceSnapshot} rows since the last snapshot (sim threshold ${SIM.snapshotEvery}, real ${REAL.snapshotEvery} rows + ${REAL.snapshotMinIntervalS} s). Node ${holderNode.id} forks the published view (O(1)) and encodes it off the apply path`,
+    );
+    await this.sleep(700);
+    s.snapshot = { appliedIdx, size, takenAt: this.now() };
+    const dropped = s.log.length;
+    s.log = [];
+    s.rowsSinceSnapshot = 0;
+    this.log(
+      'metadata',
+      `snapshot stored at applied_idx ${appliedIdx} (${size} bytes, one row per cluster). ${dropped} log rows truncated. Cold-start replay is now bounded`,
+    );
+    s.busy = false;
+  }
+
+  async killNode(nodeId: number) {
+    const s = this.s;
+    const node = s.nodes.find((n) => n.id === nodeId);
+    if (!node || node.status !== 'running') return;
+    s.busy = true;
+    node.status = 'dead';
+    node.glow = '';
+    node.memory = this.nodeMemory();
+    this.log('lifecycle', `node ${nodeId} killed. Its in-memory state (view, log cache, gates) is gone. Postgres and S3 still hold everything durable`);
+
+    const lost = s.walBuffer.filter((r) => r.nodeId === nodeId);
+    if (lost.length) {
+      s.walBuffer = s.walBuffer.filter((r) => r.nodeId !== nodeId);
+      this.log(
+        'data',
+        `${lost.length} unflushed buffered record${lost.length === 1 ? '' : 's'} on node ${nodeId} are gone. They were never acked.`,
+      );
+    }
+
+    if (node.leaseHolder) {
+      node.leaseHolder = false;
+      const next = s.nodes.find((n) => n.status === 'running');
+      if (next) {
+        next.leaseHolder = true;
+        s.lease = { holder: `node-${next.id}`, ttlMs: 10_000 };
+        this.log('lifecycle', `lease expires after its 10 s TTL. Node ${next.id} wins the next election`);
+        await this.sleep(500);
+      } else {
+        s.lease = null;
+      }
+    }
+
+    const orphans = s.streams.filter((x) => x.nodeId === nodeId);
+    const survivors = s.nodes.filter((n) => n.status === 'running');
+    if (!survivors.length) {
+      this.log('lifecycle', 'no nodes left running. Streams stay owned by a dead epoch until something restarts');
+      s.busy = false;
+      return;
+    }
+    for (const [i, stream] of orphans.entries()) {
+      const to = survivors[i % survivors.length];
+      const newEpoch = stream.epoch + 1;
+      this.log(
+        'lifecycle',
+        `stream ${stream.id} ("${stream.name}") is orphaned. Real handoff is pending transfer, source drain/close, then CompleteTransfer. Sim collapses that into a force-reassign onto node ${to.id}.`,
+      );
+      const xfer = enc.transferStream(stream.id, nodeId, to.id);
+      await this.propose(to.id, [xfer], () => {
+        stream.nodeId = to.id;
+      });
+      this.log(
+        'lifecycle',
+        `TransferStream applied. Opening at epoch ${newEpoch} fences anything still in flight from node ${nodeId}.`,
+      );
+      const open = enc.openStream(to.id, to.epoch, stream.id, newEpoch);
+      const done = enc.completeTransfer(stream.id, newEpoch);
+      await this.propose(to.id, [open, done], () => {
+        stream.epoch = newEpoch;
+        stream.localEnd = Math.max(stream.localEnd, stream.durableEnd, stream.endOffset);
+      });
+
+      const recoverable = s.sealedWal.filter(
+        (w) => w.nodeId === nodeId && w.ranges.some((r) => r.streamId === stream.id && r.end > stream.endOffset),
+      );
+      if (recoverable.length) {
+        for (const sealed of recoverable) {
+          sealed.nodeId = to.id;
+          this.log(
+            'data',
+            `WAL recovery: sealed object ${sealed.key} covers past committed end ${stream.endOffset}. Reassigned to node ${to.id}. Commit sealed to publish it.`,
+          );
+        }
+        await this.sleep(400);
+      }
+    }
+    s.busy = false;
+  }
+
+  async restartNode(nodeId: number) {
+    const s = this.s;
+    const node = s.nodes.find((n) => n.id === nodeId);
+    if (!node || node.status !== 'dead') return;
+    s.busy = true;
+    node.status = 'restoring';
+    node.epoch += 1;
+    this.log('lifecycle', `node ${nodeId} restarting at epoch ${node.epoch}. Cold start: load the snapshot, replay the tail`);
+    await this.sleep(500);
+    if (s.snapshot) {
+      this.log(
+        'metadata',
+        `node ${nodeId} decodes the snapshot (${s.snapshot.size} bytes, state at applied_idx ${s.snapshot.appliedIdx}). Secondary indexes are rebuilt from primaries, never serialized`,
+      );
+      await this.sleep(700);
+    } else {
+      this.log('metadata', `no snapshot yet. Node ${nodeId} replays the log from row 1`);
+    }
+    for (const row of s.log) {
+      node.memory.appliedIndex = row.idx;
+      this.log('metadata', `node ${nodeId} replays row ${row.idx}: ${row.commands.map((c) => c.name).join(' + ')}`);
+      await this.sleep(220);
+    }
+    const stranded = s.sealedWal.filter((w) => w.nodeId === nodeId);
+    if (stranded.length) {
+      this.log(
+        'data',
+        `node ${nodeId} still has ${stranded.length} sealed WAL object${stranded.length === 1 ? '' : 's'} under its old session. Streams that moved away recover those on open. Leftovers stay until a later owner claims them.`,
+      );
+      await this.sleep(400);
+    }
+    const cmd = enc.registerNode(nodeId, node.epoch, `http://10.0.0.${nodeId}:4437`, node.slots);
+    await this.propose(nodeId, [cmd], () => {
+      node.status = 'running';
+    });
+    this.refreshViewMaps();
+    this.log('lifecycle', `node ${nodeId} is serving again, caught up to applied index ${node.memory.appliedIndex}`);
+    s.busy = false;
+  }
+
+  reset() {
+    Object.assign(this.s, initialState());
+    this.clock = 0;
+  }
+}

--- a/website/pages/docs/design/simulator.md
+++ b/website/pages/docs/design/simulator.md
@@ -1,0 +1,42 @@
+---
+title: Interactive cluster
+---
+
+<script setup>
+import Simulation from '../../../.vitepress/theme/simulation/Simulation.vue'
+</script>
+
+# Interactive cluster
+
+::: info Note
+An interactive model of a PicoMQ cluster. It is not a bit-exact replica of
+runtime behavior. Thresholds are compressed (`10` log rows, `4` objects, flush
+only on trigger). It is meant to show the shape of the write path: propose
+through `meta_log`, WAL staging, sealed commit, snapshot / compact / GC, and
+ownership change after a kill.
+:::
+
+<ClientOnly>
+  <Simulation />
+</ClientOnly>
+
+## Experiment
+
+1. **Create stream.** Four commands in one `meta_log` row: `CreateStream`,
+   `PlaceStream`, `OpenStream`, `PutKv`. Append is separate. Each append encodes a
+   batch into the owning node's buffer and log cache. Not durable. The
+   producer ack waits for the WAL PUT. Metadata is not involved.
+2. **Flush WAL.** At `3` buffered records here, every `~5 ms` window in a real
+   cluster. One WAL object under the node's session prefix. End offsets in
+   metadata stay put.
+3. **Commit sealed.** Sealed WAL blocks become stream-set objects.
+   `PrepareObject` + `CommitStreamSetObject` advance end offsets through
+   metadata. Covered WAL objects are deleted.
+4. **Snapshot, compact, clean.** Snapshot every `10` log rows here, `1024` rows
+   plus a `30 s` floor in production. Compact at `4` committed stream-set objects
+   here, `64` in production. Compact queues destroyed objects. Clean objects is
+   the lease holder's GC tick.
+5. **Kill / restart.** Unflushed buffer is lost. Sealed WAL on S3 is recovered
+   when the stream opens on a survivor. The sim collapses pending-transfer /
+   source-drain into a force-reassign with an epoch bump. Restart loads the
+   snapshot and replays the log tail.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and client-side demo code only; no changes to production services or cluster runtime.
> 
> **Overview**
> Adds an **Interactive cluster** design doc and VitePress sidebar entry that embeds a client-only Vue simulator for exploring PicoMQ cluster behavior.
> 
> The simulator lets readers boot 1–4 nodes, create streams, append records, and manually run background tasks (WAL flush, commit sealed, snapshot, compact, GC). A canvas shows Postgres, nodes, and object store with animated stage indicators; inspectors cover node memory, `meta_log` / snapshot / lease tables, S3 objects, and a **bytes** tab backed by `HexBytes` for field-level hex views.
> 
> New `engine.ts` drives a teaching model (compressed thresholds vs. production constants in the UI) with encoders aligned to real metadata commands, record batches, and WAL framing. **Kill/restart** illustrates lost unflushed buffers, lease handoff, simplified stream reassignment, and snapshot+log replay. The page includes a short **Experiment** walkthrough; the UI explicitly notes the model is not bit-exact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ee2d03f43c62911cfa30d4fc2452e49fecda24a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->