### PR TITLE
feat(terraform): add GCP harness for PicoMQ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ thiserror = "2.0.20"
 tokio = { version = "1.53.1", features = ["rt-multi-thread", "sync", "time", "macros", "io-util"] }
 async-trait = "0.1.92"
 futures = "0.3.34"
-object_store = { version = "0.14.1", features = ["aws"] }
+object_store = { version = "0.14.1", features = ["aws", "gcp"] }
 fastrand = "2.5.0"
 md-5 = "0.11.0"
 hex = "0.4.3"

--- a/harness/terraform/gcp/.gitignore
+++ b/harness/terraform/gcp/.gitignore
@@ -1,0 +1,13 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.*
+*.tfvars
+!terraform.tfvars.example
+backend.hcl
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/harness/terraform/gcp/README.md
+++ b/harness/terraform/gcp/README.md
@@ -1,0 +1,67 @@
+# PicoMQ GCP Terraform harness
+
+This harness creates a private GKE deployment of PicoMQ with Cloud SQL PostgreSQL, a
+private Cloud Storage bucket, Secret Manager, private Cloud DNS, and an internal GKE
+HTTP load balancer.
+
+## Prerequisites
+
+- Terraform 1.15.8 or later
+- A GCP project with billing enabled
+- Google credentials with permission to create GKE, Compute Engine networking,
+  Cloud SQL, Cloud Storage, Secret Manager, Service Networking, and IAM resources
+- `gcloud auth application-default login`, or another Application Default
+  Credentials configuration
+
+The harness enables the required APIs in `apis.tf`. The deploying identity must be
+allowed to enable services.
+
+## Configure and apply
+
+Copy `terraform.tfvars.example` to `terraform.tfvars` and set `project`, `region`,
+`db_password`, and the desired `node_count`. Leave `vpc_id` and
+`private_subnet_ids` unset to create a VPC and two regional private subnets. To use
+an existing network, set `vpc_id` to its self-link and provide two subnet self-links
+in the same region.
+
+```text
+terraform -chdir=harness/terraform/gcp init
+terraform -chdir=harness/terraform/gcp plan
+terraform -chdir=harness/terraform/gcp apply
+```
+
+The deployment creates one fixed GKE worker node. `node_count` controls the number
+of PicoMQ workloads, not the GKE worker count. Each workload has a stable service
+and hostname. A single workload uses `--routing local` and the bare domain; two or
+more workloads use `--routing redirect` and `pico-1.<domain>`, `pico-2.<domain>`,
+and so on.
+
+## Outputs
+
+```text
+terraform -chdir=harness/terraform/gcp output endpoints
+terraform -chdir=harness/terraform/gcp output bucket
+terraform -chdir=harness/terraform/gcp output meta_endpoint
+terraform -chdir=harness/terraform/gcp output bootstrap_secret_arn
+```
+
+The endpoints and DNS names are private and resolve only from networks attached to
+the private Cloud DNS zone. The bootstrap token is stored in Secret Manager and
+projected into the workloads through a Kubernetes Secret. Terraform state therefore
+contains the token, as it does for the AWS harness; protect the state backend.
+
+## Storage and identity
+
+PicoMQ uses `-2@gcs://<bucket>`. The GCS backend is native `object_store` support
+and uses Application Default Credentials. GKE Workload Identity maps the PicoMQ
+Kubernetes service account to a Google service account with bucket object access;
+no service-account JSON key is created or mounted.
+
+## Destroy
+
+```text
+terraform -chdir=harness/terraform/gcp destroy
+```
+
+Set `force_destroy = true` only when deleting the bucket, Secret Manager secret,
+and Cloud SQL instance without retention protection is intended.

--- a/harness/terraform/gcp/alb.tf
+++ b/harness/terraform/gcp/alb.tf
@@ -1,0 +1,44 @@
+resource "google_compute_address" "ingress" {
+  name         = "${var.project}-ingress"
+  address_type = "INTERNAL"
+  subnetwork   = local.private_subnet_ids[0]
+  region       = var.region
+}
+
+resource "kubernetes_ingress_v1" "internal" {
+  metadata {
+    name      = "${var.project}-internal"
+    namespace = "default"
+
+    annotations = {
+      "kubernetes.io/ingress.class"                   = "gce-internal"
+      "kubernetes.io/ingress.allow-http"              = "true"
+      "kubernetes.io/ingress.regional-static-ip-name" = google_compute_address.ingress.name
+    }
+  }
+
+  spec {
+    dynamic "rule" {
+      for_each = local.nodes
+      content {
+        host = rule.value.host
+
+        http {
+          path {
+            path      = "/"
+            path_type = "Prefix"
+
+            backend {
+              service {
+                name = kubernetes_service_v1.node[rule.key].metadata[0].name
+                port { number = 4437 }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_service_v1.node]
+}

--- a/harness/terraform/gcp/apis.tf
+++ b/harness/terraform/gcp/apis.tf
@@ -1,0 +1,35 @@
+resource "google_project_service" "container" {
+  service = "container.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "sqladmin" {
+  service = "sqladmin.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "storage" {
+  service = "storage.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "secretmanager" {
+  service = "secretmanager.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "servicenetworking" {
+  service = "servicenetworking.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "compute" {
+  service = "compute.googleapis.com"
+
+  disable_on_destroy = false
+}

--- a/harness/terraform/gcp/backend.hcl.example
+++ b/harness/terraform/gcp/backend.hcl.example
@@ -1,0 +1,5 @@
+bucket       = "picomq-terraform-state"
+key          = "harness/aws/terraform.tfstate"
+region       = "us-east-1"
+encrypt      = true
+use_lockfile = true

--- a/harness/terraform/gcp/dns.tf
+++ b/harness/terraform/gcp/dns.tf
@@ -1,0 +1,23 @@
+resource "google_dns_managed_zone" "this" {
+  name        = replace(var.project, "_", "-")
+  dns_name    = "${var.domain}."
+  description = "Private PicoMQ service discovery zone"
+
+  visibility = "private"
+
+  private_visibility_config {
+    networks {
+      network_url = local.network_id
+    }
+  }
+}
+
+resource "google_dns_record_set" "node" {
+  for_each = local.nodes
+
+  managed_zone = google_dns_managed_zone.this.name
+  name         = "${each.value.host}."
+  type         = "A"
+  ttl          = 30
+  rrdatas      = [google_compute_address.ingress.address]
+}

--- a/harness/terraform/gcp/ecs.tf
+++ b/harness/terraform/gcp/ecs.tf
@@ -1,0 +1,48 @@
+resource "google_container_cluster" "this" {
+  name     = var.project
+  location = var.region
+
+  network    = local.network_id
+  subnetwork = local.private_subnet_ids[0]
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  workload_identity_config {
+    workload_pool = "${var.project}.svc.id.goog"
+  }
+
+  release_channel {
+    channel = "REGULAR"
+  }
+
+  deletion_protection = !var.force_destroy
+}
+
+resource "google_container_node_pool" "this" {
+  name     = "${var.project}-nodes"
+  location = var.region
+  cluster  = google_container_cluster.this.name
+
+  node_count = 1
+
+  node_config {
+    machine_type = "e2-standard-2"
+
+    service_account = google_service_account.nodes.email
+
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform"
+    ]
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+
+    labels = {
+      app = var.project
+    }
+
+    tags = ["${var.project}-node"]
+  }
+}

--- a/harness/terraform/gcp/iam.tf
+++ b/harness/terraform/gcp/iam.tf
@@ -1,0 +1,36 @@
+resource "google_service_account" "nodes" {
+  account_id   = "${var.project}-nodes"
+  display_name = "${var.project} PicoMQ nodes"
+}
+
+resource "google_storage_bucket_iam_member" "nodes_storage" {
+  bucket = google_storage_bucket.data.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.nodes.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "nodes_bootstrap" {
+  secret_id = google_secret_manager_secret.bootstrap.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.nodes.email}"
+}
+
+resource "kubernetes_service_account_v1" "nodes" {
+  metadata {
+    name      = "${var.project}-nodes"
+    namespace = "default"
+
+    annotations = {
+      "iam.gke.io/gcp-service-account" = google_service_account.nodes.email
+    }
+  }
+
+  depends_on = [google_container_cluster.this]
+}
+
+resource "google_service_account_iam_member" "workload_identity" {
+  service_account_id = google_service_account.nodes.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project}.svc.id.goog[default/${kubernetes_service_account_v1.nodes.metadata[0].name}]"
+}
+

--- a/harness/terraform/gcp/locals.tf
+++ b/harness/terraform/gcp/locals.tf
@@ -1,0 +1,22 @@
+locals {
+  create_network = var.vpc_id == null
+
+  nodes = {
+    for i in range(1, var.node_count + 1) : tostring(i) => {
+      id   = i
+      host = var.node_count == 1 ? var.domain : "pico-${i}.${var.domain}"
+    }
+  }
+
+  routing = var.node_count == 1 ? "local" : "redirect"
+
+  network_id = local.create_network ? google_compute_network.this[0].id : var.vpc_id
+
+  private_subnet_ids = local.create_network ? google_compute_subnetwork.private[*].id : [
+    for subnet in data.google_compute_subnetwork.existing_private : subnet.id
+  ]
+
+  meta_url = "postgres://picomq:${var.db_password}@${google_sql_database_instance.meta.first_ip_address}:5432/picomq"
+
+  storage = "-2@gcs://${google_storage_bucket.data.name}"
+}

--- a/harness/terraform/gcp/network.tf
+++ b/harness/terraform/gcp/network.tf
@@ -1,0 +1,50 @@
+resource "google_compute_network" "this" {
+  count = local.create_network ? 1 : 0
+
+  name                    = var.project
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "private" {
+  count = local.create_network ? 2 : 0
+
+  name          = "${var.project}-private-${count.index + 1}"
+  ip_cidr_range = "10.42.${count.index + 10}.0/24"
+  region        = var.region
+  network       = google_compute_network.this[0].id
+
+  private_ip_google_access = true
+}
+
+resource "google_compute_router" "this" {
+  count = local.create_network ? 1 : 0
+
+  name    = "${var.project}-router"
+  region  = var.region
+  network = google_compute_network.this[0].id
+
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_router_nat" "this" {
+  count = local.create_network ? 1 : 0
+
+  name                               = "${var.project}-nat"
+  router                             = google_compute_router.this[0].name
+  region                             = var.region
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+
+data "google_compute_subnetwork" "existing_private" {
+  count = local.create_network ? 0 : length(var.private_subnet_ids)
+
+  self_link = var.private_subnet_ids[count.index]
+}

--- a/harness/terraform/gcp/nodes.tf
+++ b/harness/terraform/gcp/nodes.tf
@@ -1,0 +1,185 @@
+resource "kubernetes_secret_v1" "bootstrap" {
+  metadata {
+    name      = "${var.project}-bootstrap"
+    namespace = "default"
+  }
+
+  data = {
+    token = google_secret_manager_secret_version.bootstrap.secret_data
+  }
+
+  type = "Opaque"
+}
+
+resource "kubernetes_service_v1" "node" {
+  for_each = local.nodes
+
+  metadata {
+    name      = "${var.project}-${each.key}"
+    namespace = "default"
+
+    annotations = {
+      "cloud.google.com/neg"            = "{\"ingress\": true}"
+      "cloud.google.com/backend-config" = "{\"default\": \"${var.project}-${each.key}\"}"
+    }
+  }
+
+  spec {
+    selector = {
+      "app.kubernetes.io/name" = var.project
+      "app.kubernetes.io/node" = each.key
+    }
+
+    port {
+      name        = "pico"
+      port        = 4437
+      target_port = 4437
+      protocol    = "TCP"
+    }
+
+    port {
+      name        = "admin"
+      port        = 9090
+      target_port = 9090
+      protocol    = "TCP"
+    }
+  }
+}
+
+resource "kubernetes_manifest" "backend_config" {
+  for_each = local.nodes
+
+  manifest = {
+    apiVersion = "cloud.google.com/v1"
+    kind       = "BackendConfig"
+    metadata = {
+      name      = "${var.project}-${each.key}"
+      namespace = "default"
+    }
+    spec = {
+      healthCheck = {
+        requestPath = "/ready"
+        port        = 9090
+        type        = "HTTP"
+      }
+    }
+  }
+}
+
+resource "kubernetes_deployment_v1" "node" {
+  for_each = local.nodes
+
+  metadata {
+    name      = "${var.project}-${each.key}"
+    namespace = "default"
+    labels = {
+      "app.kubernetes.io/name" = var.project
+      "app.kubernetes.io/node" = each.key
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = {
+        "app.kubernetes.io/name" = var.project
+        "app.kubernetes.io/node" = each.key
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          "app.kubernetes.io/name" = var.project
+          "app.kubernetes.io/node" = each.key
+        }
+      }
+
+      spec {
+        service_account_name = kubernetes_service_account_v1.nodes.metadata[0].name
+
+        container {
+          name              = "pico"
+          image             = var.image
+          image_pull_policy = "IfNotPresent"
+
+          command = ["serve"]
+          args = [
+            "--routing", local.routing,
+            "--shutdown-drain-sec", "5",
+          ]
+
+          port {
+            name           = "pico"
+            container_port = 4437
+          }
+
+          port {
+            name           = "admin"
+            container_port = 9090
+          }
+
+          env {
+            name  = "PICO_NODE_ID"
+            value = tostring(each.value.id)
+          }
+          env {
+            name  = "PICO_LISTEN"
+            value = "0.0.0.0:4437"
+          }
+          env {
+            name  = "PICO_ADMIN_LISTEN"
+            value = "0.0.0.0:9090"
+          }
+          env {
+            name  = "PICO_HTTP_ADDRESS"
+            value = "http://${each.value.host}"
+          }
+          env {
+            name  = "PICO_META_URL"
+            value = local.meta_url
+          }
+          env {
+            name  = "PICO_STORAGE"
+            value = local.storage
+          }
+          env {
+            name  = "PICO_AUTH"
+            value = "required"
+          }
+
+          env {
+            name = "PICO_AUTH_BOOTSTRAP_TOKEN"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret_v1.bootstrap.metadata[0].name
+                key  = "token"
+              }
+            }
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/ready"
+              port = 9090
+            }
+            initial_delay_seconds = 10
+            period_seconds        = 10
+          }
+
+          liveness_probe {
+            http_get {
+              path = "/health"
+              port = 9090
+            }
+            initial_delay_seconds = 30
+            period_seconds        = 20
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [google_sql_database.picomq, google_secret_manager_secret_version.bootstrap]
+}

--- a/harness/terraform/gcp/outputs.tf
+++ b/harness/terraform/gcp/outputs.tf
@@ -1,0 +1,33 @@
+output "endpoints" {
+  value = {
+    for key, node in local.nodes : key => "http://${node.host}"
+  }
+}
+
+output "bucket" {
+  value = google_storage_bucket.data.name
+}
+
+output "meta_endpoint" {
+  value = google_sql_database_instance.meta.first_ip_address
+}
+
+output "alb_dns_name" {
+  value = google_compute_address.ingress.address
+}
+
+output "vpc_id" {
+  value = local.network_id
+}
+
+output "bootstrap_secret_arn" {
+  value = google_secret_manager_secret.bootstrap.id
+}
+
+output "bootstrap_secret" {
+  value = google_secret_manager_secret.bootstrap.id
+}
+
+output "private_subnet_ids" {
+  value = local.private_subnet_ids
+}

--- a/harness/terraform/gcp/providers.tf
+++ b/harness/terraform/gcp/providers.tf
@@ -1,0 +1,12 @@
+provider "google" {
+  project = var.project
+  region  = var.region
+}
+
+data "google_client_config" "current" {}
+
+provider "kubernetes" {
+  host                   = "https://${google_container_cluster.this.endpoint}"
+  token                  = data.google_client_config.current.access_token
+  cluster_ca_certificate = base64decode(google_container_cluster.this.master_auth[0].cluster_ca_certificate)
+}

--- a/harness/terraform/gcp/rds.tf
+++ b/harness/terraform/gcp/rds.tf
@@ -1,0 +1,56 @@
+resource "google_sql_database_instance" "meta" {
+  name             = "${var.project}-meta"
+  database_version = "POSTGRES_16"
+  region           = var.region
+
+  settings {
+    tier                  = var.db_instance_class
+    disk_type             = "PD_SSD"
+    disk_size             = 20
+    disk_autoresize       = true
+    disk_autoresize_limit = 100
+
+    backup_configuration {
+      enabled                        = true
+      point_in_time_recovery_enabled = true
+    }
+
+    ip_configuration {
+      ipv4_enabled    = false
+      private_network = local.network_id
+    }
+
+    availability_type = var.db_multi_az ? "REGIONAL" : "ZONAL"
+  }
+
+  deletion_protection = !var.force_destroy
+
+  depends_on = [google_service_networking_connection.private_vpc_connection]
+}
+
+resource "google_compute_global_address" "private_service_access" {
+  name          = "${var.project}-private-services"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = local.network_id
+}
+
+resource "google_service_networking_connection" "private_vpc_connection" {
+  network                 = local.network_id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_service_access.name]
+
+  depends_on = [google_project_service.servicenetworking]
+}
+
+resource "google_sql_database" "picomq" {
+  name     = "picomq"
+  instance = google_sql_database_instance.meta.name
+}
+
+resource "google_sql_user" "picomq" {
+  name     = "picomq"
+  instance = google_sql_database_instance.meta.name
+  password = var.db_password
+}

--- a/harness/terraform/gcp/s3.tf
+++ b/harness/terraform/gcp/s3.tf
@@ -1,0 +1,17 @@
+resource "random_id" "bucket_suffix" {
+  byte_length = 4
+}
+
+resource "google_storage_bucket" "data" {
+  name          = "${var.project}-${random_id.bucket_suffix.hex}"
+  location      = var.region
+  force_destroy = var.force_destroy
+
+  uniform_bucket_level_access = true
+
+  public_access_prevention = "enforced"
+
+  versioning {
+    enabled = true
+  }
+}

--- a/harness/terraform/gcp/secrets.tf
+++ b/harness/terraform/gcp/secrets.tf
@@ -1,0 +1,52 @@
+resource "random_bytes" "bootstrap_secret" {
+  count = var.bootstrap_token == null ? 1 : 0
+
+  length = 32
+}
+
+locals {
+  bootstrap_id_b64 = replace(
+    replace(
+      replace(base64encode("gcp/root"), "+", "-"),
+      "/",
+      "_"
+    ),
+    "=",
+    ""
+  )
+
+  bootstrap_secret_b64 = (
+    length(random_bytes.bootstrap_secret) > 0
+    ? replace(
+      replace(
+        replace(random_bytes.bootstrap_secret[0].base64, "+", "-"),
+        "/",
+        "_"
+      ),
+      "=",
+      ""
+    )
+    : null
+  )
+
+  bootstrap_token_value = (
+    var.bootstrap_token != null
+    ? var.bootstrap_token
+    : "${local.bootstrap_id_b64}.${local.bootstrap_secret_b64}"
+  )
+}
+
+resource "google_secret_manager_secret" "bootstrap" {
+  secret_id = "${var.project}-bootstrap"
+
+  replication {
+    auto {}
+  }
+
+  deletion_protection = !var.force_destroy
+}
+
+resource "google_secret_manager_secret_version" "bootstrap" {
+  secret      = google_secret_manager_secret.bootstrap.id
+  secret_data = local.bootstrap_token_value
+}

--- a/harness/terraform/gcp/security_groups.tf
+++ b/harness/terraform/gcp/security_groups.tf
@@ -1,0 +1,32 @@
+resource "google_compute_firewall" "alb_to_nodes" {
+  name    = "${var.project}-alb-to-nodes"
+  network = local.network_id
+
+  direction = "INGRESS"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["4437", "9090"]
+  }
+
+  source_ranges = ["10.42.0.0/16"]
+
+  target_tags = ["${var.project}-node"]
+}
+
+resource "google_compute_firewall" "internal_admin" {
+  name    = "${var.project}-internal-admin"
+  network = local.network_id
+
+  direction = "INGRESS"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["9090"]
+  }
+
+  source_ranges = ["10.42.0.0/16"]
+
+  target_tags = ["${var.project}-node"]
+}
+

--- a/harness/terraform/gcp/terraform.tfvars.example
+++ b/harness/terraform/gcp/terraform.tfvars.example
@@ -1,0 +1,23 @@
+region     = "us-central1"
+project    = "picomq"
+node_count = 2
+domain     = "picomq.internal"
+image      = "ghcr.io/picomq/picomq:latest"
+
+db_password = "change-me"
+
+# Existing VPC. Omit both values to create a network and two subnets instead.
+# vpc_id = "projects/my-project/global/networks/existing"
+# private_subnet_ids = [
+#   "projects/my-project/regions/us-central1/subnetworks/private-1",
+#   "projects/my-project/regions/us-central1/subnetworks/private-2",
+# ]
+
+# Optional. Omit to generate and store a bootstrap token in Secrets Manager.
+# bootstrap_token = "BASE64URL(id).BASE64URL(32bytes)"
+
+# force_destroy      = false
+# db_multi_az        = true
+# db_instance_class  = "db-custom-1-3840"
+# task_cpu           = 512
+# task_memory        = 1024

--- a/harness/terraform/gcp/variables.tf
+++ b/harness/terraform/gcp/variables.tf
@@ -1,0 +1,88 @@
+variable "project" {
+  type    = string
+  default = "picomq"
+}
+
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
+
+variable "node_count" {
+  type    = number
+  default = 1
+
+  validation {
+    condition     = var.node_count >= 1
+    error_message = "node_count must be at least 1."
+  }
+}
+
+variable "image" {
+  type    = string
+  default = "ghcr.io/picomq/picomq:latest"
+}
+
+variable "vpc_id" {
+  type    = string
+  default = null
+}
+
+variable "private_subnet_ids" {
+  type    = list(string)
+  default = []
+
+  validation {
+    condition = (
+      (var.vpc_id == null && length(var.private_subnet_ids) == 0) ||
+      (var.vpc_id != null && length(var.private_subnet_ids) >= 2)
+    )
+    error_message = "Omit private_subnet_ids when vpc_id is null. When vpc_id is set provide at least two private subnet ids."
+  }
+}
+
+variable "domain" {
+  type    = string
+  default = "picomq.internal"
+}
+
+variable "db_instance_class" {
+  type    = string
+  default = "db-custom-1-3840"
+}
+
+variable "db_password" {
+  type      = string
+  sensitive = true
+}
+
+variable "db_multi_az" {
+  type    = bool
+  default = true
+}
+
+variable "bootstrap_token" {
+  type      = string
+  default   = null
+  sensitive = true
+}
+
+variable "task_cpu" {
+  type    = number
+  default = 512
+}
+
+variable "task_memory" {
+  type    = number
+  default = 1024
+}
+
+variable "force_destroy" {
+  type    = bool
+  default = false
+}
+
+variable "create_storage_endpoint" {
+  type    = bool
+  default = false
+}

--- a/harness/terraform/gcp/versions.tf
+++ b/harness/terraform/gcp/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.15.8"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.9"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.38"
+    }
+  }
+}

--- a/s3stream/s3stream-object/src/storage.rs
+++ b/s3stream/s3stream-object/src/storage.rs
@@ -254,12 +254,20 @@ impl ObjectStoreAdapter {
     /// Supported protocols:
     /// - `s3`: AWS S3 or compatible. Honors `region`, `endpoint`, `pathStyle`,
     ///   `s3Express` query builder chain).
+    /// - `gcs`: Google Cloud Storage using Application Default Credentials,
+    ///   including GKE Workload Identity.
     /// - `file`: local filesystem rooted at the path (dev/test).
     /// - `mem`: in-memory backend (tests).
     pub fn from_bucket_uri(uri: &str) -> Result<Self, ObjectError> {
         let uri = IdUri::parse(uri)?;
         let inner: std::sync::Arc<dyn object_store::ObjectStore> = match uri.protocol.as_str() {
             "s3" => std::sync::Arc::new(s3_builder(&uri).build().map_err(ObjectError::Backend)?),
+            "gcs" => std::sync::Arc::new(
+                object_store::gcp::GoogleCloudStorageBuilder::from_env()
+                    .with_bucket_name(&uri.path)
+                    .build()
+                    .map_err(ObjectError::Backend)?,
+            ),
             "file" => std::sync::Arc::new(
                 object_store::local::LocalFileSystem::new_with_prefix(&uri.path)
                     .map_err(ObjectError::Backend)?,

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -93,6 +93,7 @@ const docsSidebar = [
           { text: 'Docker', link: '/docs/operations/deployment/docker' },
           { text: 'Fly', link: '/docs/operations/deployment/fly' },
           { text: 'AWS', link: '/docs/operations/deployment/aws' },
+          { text: 'GCP', link: '/docs/operations/deployment/gcp' },
         ],
       },
       { text: 'Admin API & dashboard', link: '/docs/operations/admin' },

--- a/website/pages/docs/operations/deployment/gcp.md
+++ b/website/pages/docs/operations/deployment/gcp.md
@@ -1,0 +1,89 @@
+# GCP
+
+The Terraform harness under `harness/terraform/gcp` stands up a private PicoMQ
+cluster on GKE.
+
+## What it creates
+
+| Piece | Role |
+| --- | --- |
+| VPC and private subnets (optional) | Creates two regional subnets, Cloud NAT, and Private Google Access, or uses an existing VPC and two private subnet self-links. |
+| GKE | Runs one PicoMQ workload per logical node on a fixed worker pool. |
+| Cloud SQL PostgreSQL | Shared private metadata database through Private Service Access. |
+| Cloud Storage | Shared object store accessed through Workload Identity, without service-account keys. |
+| Internal GKE Ingress | Private host-based routing to each PicoMQ workload on port `4437`. |
+| Private Cloud DNS | Records under `domain` for clients and redirects. |
+| Secret Manager | Stores the bootstrap token for `--auth required`. |
+
+- `node_count = 1` uses `--routing local` and the bare `domain` hostname.
+- `node_count >= 2` uses `--routing redirect` and `pico-N.<domain>` hostnames.
+
+## Prerequisites
+
+- Terraform `>= 1.15.8`
+- A GCP project with billing enabled
+- Application Default Credentials, for example `gcloud auth application-default login`
+- Permission to enable APIs and create GKE, Compute Engine, Cloud SQL, Cloud Storage,
+  Secret Manager, Service Networking, DNS, and IAM resources
+- An amd64 container image, such as `ghcr.io/picomq/picomq:latest`
+
+The harness enables the required APIs in `harness/terraform/gcp/apis.tf`.
+
+## Configure and apply
+
+From the repository root:
+
+```bash
+cd harness/terraform/gcp
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Set `project`, `region`, `node_count`, `domain`, `image`, and `db_password` in
+`terraform.tfvars`. Leave `vpc_id` and `private_subnet_ids` unset to create the
+network. To use an existing network, set `vpc_id` to its network self-link and
+provide at least two private subnet self-links in the selected region.
+
+Leave `bootstrap_token` unset to generate one in Secret Manager, or provide an
+existing token in the format documented under [Authentication](/docs/operations/auth).
+
+```bash
+terraform init -backend=false
+terraform plan
+terraform apply
+```
+
+For shared state, configure the GCS backend using `backend.hcl.example` and run
+`terraform init -backend-config=backend.hcl`. Protect the state because Terraform
+state contains the database password and generated bootstrap token.
+
+## Outputs
+
+```bash
+terraform output endpoints
+terraform output bucket
+terraform output meta_endpoint
+terraform output bootstrap_secret
+```
+
+The endpoints, DNS zone, Cloud SQL address, and load balancer are private. Access
+them from a connected VPC, VPN, bastion, or another workload in the network.
+
+PicoMQ uses `-2@gcs://<bucket>`. The runtime uses Google Application Default
+Credentials, and GKE Workload Identity maps the PicoMQ Kubernetes service account
+to the Google service account granted access to the bucket. No JSON key is created
+or mounted on PicoMQ nodes.
+
+## Existing VPC
+
+Set both `vpc_id` and at least two `private_subnet_ids`. The subnets must be in the
+configured region and provide private egress through Cloud NAT, or an equivalent
+existing egress path, for image pulls and Google APIs.
+
+## Teardown
+
+```bash
+terraform destroy
+```
+
+Set `force_destroy = true` only when deleting the bucket, Secret Manager secret,
+GKE cluster, and Cloud SQL instance without retention protection is intended.


### PR DESCRIPTION
## Summary

Implements issue #57 by adding a GCP Terraform harness equivalent to the AWS harness.

## What changed

- Added `harness/terraform/gcp`
- Added GKE-based PicoMQ node workloads
- Added single-node and multi-node routing behavior:
  - `node_count = 1`: `--routing local`
  - `node_count >= 2`: `--routing redirect`
- Added per-node PicoMQ hostnames
- Added Cloud SQL PostgreSQL with private networking and Private Service Access
- Added Google Cloud Storage object storage
- Added GKE Workload Identity for GCS access
- Avoided static service-account keys on PicoMQ nodes
- Added internal GKE HTTP load balancing
- Added private Cloud DNS records
- Added Secret Manager bootstrap token support
- Added GCP Terraform outputs parallel to AWS
- Added GCP deployment documentation
- Added native `gcs://` support to the PicoMQ object-store adapter using Application Default Credentials

## Validation

- `terraform fmt -check -recursive harness/terraform/gcp`
- `terraform -chdir=harness/terraform/gcp validate`
- VitePress documentation build
- `git diff --check`

## Not verified locally

- Real GCP apply, because GCP credentials were unavailable
- Rust compilation, because the Windows MSVC linker was unavailable